### PR TITLE
Migration Cleanup

### DIFF
--- a/Owncloud iOs Client/DataBase/Queries/InitializeDatabase.m
+++ b/Owncloud iOs Client/DataBase/Queries/InitializeDatabase.m
@@ -65,179 +65,44 @@
         [ManageDB removeTable:@"files_backup"];
         [ManageDB createDataBase];
     } else {
+        //Switch uses fallthrough to handle migrations - don't add "break" to your migration
         switch ([ManageDB getDatabaseVersion]) {
             case k_DB_version_1:
                 [ManageDB updateDBVersion1To2];
-                [ManageDB updateDBVersion2To3];
-                [ManageDB updateDBVersion3To4];
-                [ManageDB updateDBVersion4To5];
-                [ManageDB updateDBVersion5To6];
-                [ManageDB updateDBVersion6To7];
-                [self updateDBVersion7To8];
-                [ManageDB updateDBVersion8To9];
-                [ManageDB updateDBVersion9To10];
-                [ManageDB updateDBVersion10To11];
-                [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_2:
                 [ManageDB updateDBVersion2To3];
                 [self removeURLEncodingFromAllFilesAndFoldersInTheFileSystem];
-                [ManageDB updateDBVersion3To4];
-                [ManageDB updateDBVersion4To5];
-                [ManageDB updateDBVersion5To6];
-                [ManageDB updateDBVersion6To7];
-                [self updateDBVersion7To8];
-                [ManageDB updateDBVersion8To9];
-                [ManageDB updateDBVersion9To10];
-                [ManageDB updateDBVersion10To11];
-                [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_3:
                 [ManageDB updateDBVersion3To4];
-                [ManageDB updateDBVersion4To5];
-                [ManageDB updateDBVersion5To6];
-                [ManageDB updateDBVersion6To7];
-                [self updateDBVersion7To8];
-                [ManageDB updateDBVersion8To9];
-                [ManageDB updateDBVersion9To10];
-                [ManageDB updateDBVersion10To11];
-                [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_4:
                 [ManageDB updateDBVersion4To5];
-                [ManageDB updateDBVersion5To6];
-                [ManageDB updateDBVersion6To7];
-                [self updateDBVersion7To8];
-                [ManageDB updateDBVersion8To9];
-                [ManageDB updateDBVersion9To10];
-                [ManageDB updateDBVersion10To11];
-                [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_5:
                 [ManageDB updateDBVersion5To6];
-                [ManageDB updateDBVersion6To7];
-                [self updateDBVersion7To8];
-                [ManageDB updateDBVersion8To9];
-                [ManageDB updateDBVersion9To10];
-                [ManageDB updateDBVersion10To11];
-                [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_6:
                 [ManageDB updateDBVersion6To7];
-                [self updateDBVersion7To8];
-                [ManageDB updateDBVersion8To9];
-                [ManageDB updateDBVersion9To10];
-                [ManageDB updateDBVersion10To11];
-                [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_7:
                 [self updateDBVersion7To8];
-                [ManageDB updateDBVersion8To9];
-                [ManageDB updateDBVersion9To10];
-                [ManageDB updateDBVersion10To11];
-                [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_8:
                 [ManageDB updateDBVersion8To9];
-                [ManageDB updateDBVersion9To10];
-                [ManageDB updateDBVersion10To11];
-                [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_9:
                 [ManageDB updateDBVersion9To10];
-                [ManageDB updateDBVersion10To11];
-                [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_10:
                 [ManageDB updateDBVersion10To11];
-                [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_11:
                 [ManageDB updateDBVersion11To12];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_12:
                 [ManageDB updateDBVersion12To13];
                 //Update keychain of all the users
                 [OCKeychain updateAllKeychainsToUseTheLockProperty];
-                [ManageDB updateDBVersion12To13];
-                [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_13:
                 [ManageDB updateDBVersion13To14];
-                [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_14:
                 [ManageDB updateDBVersion14To15];
-                [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_15:
                 [ManageDB updateDBVersion15To16];
-                [self updateDBVersion16To17];
-                break;
             case k_DB_version_16:
                 [self updateDBVersion16To17];
-                break;
+                break; //Insert your migration above this final break.
         }
     }
     


### PR DESCRIPTION
InitializeDatabase.m now takes advantage of switch fallthrough to clean up DB migrations.