### PR TITLE
Instant Upload now uses modification date, not creation date, to filter photos to upload.

### DIFF
--- a/Owncloud iOs Client/InstantUpload/InstantUpload.m
+++ b/Owncloud iOs Client/InstantUpload/InstantUpload.m
@@ -152,18 +152,18 @@
                 NSDate *lastInstantUploadedAssetCaptureDate = [NSDate dateWithTimeIntervalSince1970:ACTIVE_USER.timestampInstantUpload];
                 
                 PHFetchOptions *newAssetsFetchOptions = [PHFetchOptions new];
-                newAssetsFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:YES]];
-                newAssetsFetchOptions.predicate = [NSPredicate predicateWithFormat:@"creationDate > %@", lastInstantUploadedAssetCaptureDate];
+                newAssetsFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"modificationDate" ascending:YES]];
+                newAssetsFetchOptions.predicate = [NSPredicate predicateWithFormat:@"modificationDate > %@", lastInstantUploadedAssetCaptureDate];
                 
                 PHFetchResult *newPhotos = [PHAsset fetchAssetsWithMediaType:PHAssetMediaTypeImage options:newAssetsFetchOptions];
                 
                 if (newPhotos != nil && [newPhotos count] != 0) {
                     
                     for (PHAsset *image in newPhotos) {
-                        NSTimeInterval assetDateCreated = [image.creationDate timeIntervalSince1970];
-                        if (assetDateCreated > ACTIVE_USER.timestampInstantUpload) {
-                            ACTIVE_USER.timestampInstantUpload = assetDateCreated;
-                            [ManageAppSettingsDB updateTimestampInstantUpload:assetDateCreated];
+                        NSTimeInterval assetModifiedDate = [image.modificationDate timeIntervalSince1970];
+                        if (assetModifiedDate > ACTIVE_USER.timestampInstantUpload) {
+                            ACTIVE_USER.timestampInstantUpload = assetModifiedDate;
+                            [ManageAppSettingsDB updateTimestampInstantUpload:assetModifiedDate];
                         }
                     }
                     

--- a/Owncloud iOs Client/Utils/FileNameUtils.m
+++ b/Owncloud iOs Client/Utils/FileNameUtils.m
@@ -484,7 +484,7 @@
     [dateFormatter setDateFormat:@"yyyy-MM-dd-HH-mm-ss"];
     dateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
 
-    NSString *dateString = [dateFormatter stringFromDate:asset.creationDate];
+    NSString *dateString = [dateFormatter stringFromDate:asset.modificationDate];
     NSString *fileName = [asset valueForKey:@"filename"];
     NSString *fileExtension = [fileName pathExtension];
     


### PR DESCRIPTION
Closes  #710 

PHAsset File Naming now based on Modification Date rather than Creation Date.

Instant Upload now filters images to upload based on their modification date rather than their creation date.

___

BUGS & IMPROVEMENTS:

- [ ] Old images queued twice https://github.com/owncloud/ios/pull/718#issuecomment-230817937