### PR TITLE
Background Instant Upload Switch Fix && Fix for requesting Photos permission on open

### DIFF
--- a/Owncloud iOs Client/InstantUpload/InstantUpload.m
+++ b/Owncloud iOs Client/InstantUpload/InstantUpload.m
@@ -49,6 +49,10 @@
         self.locationManager.delegate = self;
         [PHPhotoLibrary.sharedPhotoLibrary registerChangeObserver:self];
         [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(appLifecycleShouldTriggerInstantUpload:) name:UIApplicationWillEnterForegroundNotification object:nil];
+        
+        if (ACTIVE_USER.backgroundInstantUpload && [CLLocationManager authorizationStatus] != kCLAuthorizationStatusAuthorizedAlways) {
+            [self setBackgroundInstantUploadEnabled:NO];
+        }
     }
     return self;
 }
@@ -102,6 +106,8 @@
                 [self.locationManager startMonitoringSignificantLocationChanges];
             } else {
                 if ([CLLocationManager authorizationStatus] == kCLAuthorizationStatusNotDetermined) {
+                    ACTIVE_USER.backgroundInstantUpload = YES;
+                    [ManageAppSettingsDB updateBackgroundInstantUploadTo:YES];
                     [self.locationManager requestAlwaysAuthorization];
                 } else {
                     [self showAlertViewWithTitle:NSLocalizedString(@"location_not_enabled", nil) body:NSLocalizedString(@"message_location_not_enabled", nil)];


### PR DESCRIPTION
Fixes issue with Background Instant Upload Switch not being set to on when background instant upload is first enabled and a location services permission request is required.

Edit: I've added another commit that fixes a bug where Instant Upload requested media library access permission on open rather than when first enabling Instant Upload.

I think both of these changes, after QA, should be included in 3.5.

@mcastroSG Fixes the last instant upload bug here: https://github.com/owncloud/ios/issues/663#issuecomment-233876760
@nasli 
@jesmrec I know you were doing some QA for 3.5 so I'll mention you too.