### PR TITLE
Fixes error dialog appearance when trying to enable Instant Upload without granting media library permission.

### DIFF
--- a/Owncloud iOs Client/InstantUpload/InstantUpload.m
+++ b/Owncloud iOs Client/InstantUpload/InstantUpload.m
@@ -250,8 +250,10 @@
 #pragma mark - Utility
 
 - (void) showAlertViewWithTitle:(NSString *)title body:(NSString *)body{
-    UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:body delegate:self cancelButtonTitle:NSLocalizedString(@"ok", nil) otherButtonTitles:nil];
-    [alertView show];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        UIAlertView *alertView = [[UIAlertView alloc] initWithTitle:title message:body delegate:self cancelButtonTitle:NSLocalizedString(@"ok", nil) otherButtonTitles:nil];
+        [alertView show];
+    });
 }
 
 @end


### PR DESCRIPTION
The alert dialog just needed to be triggered on the main thread.

@mcastroSG From issue #663
@nasli 