### PR TITLE
Reverts Instant Upload back to using creation date, not modification date, to select images to upload.

### DIFF
--- a/Owncloud iOs Client/InstantUpload/InstantUpload.m
+++ b/Owncloud iOs Client/InstantUpload/InstantUpload.m
@@ -166,8 +166,8 @@
                 NSDate *lastInstantUploadedAssetCaptureDate = [NSDate dateWithTimeIntervalSince1970:ACTIVE_USER.timestampInstantUpload];
                 
                 PHFetchOptions *newAssetsFetchOptions = [PHFetchOptions new];
-                newAssetsFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"modificationDate" ascending:YES]];
-                newAssetsFetchOptions.predicate = [NSPredicate predicateWithFormat:@"modificationDate > %@", lastInstantUploadedAssetCaptureDate];
+                newAssetsFetchOptions.sortDescriptors = @[[NSSortDescriptor sortDescriptorWithKey:@"creationDate" ascending:YES]];
+                newAssetsFetchOptions.predicate = [NSPredicate predicateWithFormat:@"creationDate > %@", lastInstantUploadedAssetCaptureDate];
                 
                 PHFetchResult *cameraRollAssetCollection = [PHAssetCollection fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeSmartAlbumUserLibrary options:nil];
                 
@@ -176,10 +176,10 @@
                 if (newPhotos != nil && [newPhotos count] != 0) {
                     
                     for (PHAsset *image in newPhotos) {
-                        NSTimeInterval assetModifiedDate = [image.modificationDate timeIntervalSince1970];
-                        if (assetModifiedDate > ACTIVE_USER.timestampInstantUpload) {
-                            ACTIVE_USER.timestampInstantUpload = assetModifiedDate;
-                            [ManageAppSettingsDB updateTimestampInstantUpload:assetModifiedDate];
+                        NSTimeInterval assetCreatedDate = [image.creationDate timeIntervalSince1970];
+                        if (assetCreatedDate > ACTIVE_USER.timestampInstantUpload) {
+                            ACTIVE_USER.timestampInstantUpload = assetCreatedDate;
+                            [ManageAppSettingsDB updateTimestampInstantUpload:assetCreatedDate];
                         }
                     }
                     

--- a/Owncloud iOs Client/Utils/FileNameUtils.m
+++ b/Owncloud iOs Client/Utils/FileNameUtils.m
@@ -484,7 +484,7 @@
     [dateFormatter setDateFormat:@"yyyy-MM-dd-HH-mm-ss"];
     dateFormatter.locale = [[NSLocale alloc] initWithLocaleIdentifier:@"en_US_POSIX"];
 
-    NSString *dateString = [dateFormatter stringFromDate:asset.modificationDate];
+    NSString *dateString = [dateFormatter stringFromDate:asset.creationDate];
     NSString *fileName = [asset valueForKey:@"filename"];
     NSString *fileExtension = [fileName pathExtension];
     


### PR DESCRIPTION
Fixes an issue where live photos are uploaded multiple times due to the system making changes to the modification date shortly after taking them, identified Issue #746 

@nasli @jesmrec 

Fixes #746 