### PR TITLE
[login] match color of login button with the icon

### DIFF
--- a/Owncloud iOs Client/Branding/UIColor+Constants.m
+++ b/Owncloud iOs Client/Branding/UIColor+Constants.m
@@ -132,7 +132,7 @@
 
 //Background color of login button
 +(UIColor *)colorOfLoginButtonBackground{
-    return [UIColor colorWithRed:96/255.0f green:133/255.0f blue:154/255.0f alpha:1.0];
+    return [UIColor colorWithRed:30/255.0f green:44/255.0f blue:67/255.0f alpha:1.0];
 }
 
 //Text color of the text of the login button


### PR DESCRIPTION
Get cloud color of the icon using a color picking tool and set the
background color of the login button to that color.

This commit is fixing owncloud/ios#870