### PR TITLE
Fix SAML login

### DIFF
--- a/Owncloud iOs Client/Login/SSO/SSOViewController.m
+++ b/Owncloud iOs Client/Login/SSO/SSOViewController.m
@@ -401,7 +401,8 @@ static NSString *const tmpFileName = @"tmp.der";
     if (error.code == kCFURLErrorHTTPTooManyRedirects) {
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"unknow_response_server", nil) message:NSLocalizedString(@"", nil) delegate:nil cancelButtonTitle:NSLocalizedString(@"ok", nil) otherButtonTitles:nil];
         [alert show];
-        [self retry:nil];
+        
+        [self initParemetersAndRetryOpenLink];
         
     } else if ([error.domain isEqualToString: NSURLErrorDomain]) {
         
@@ -412,7 +413,7 @@ static NSString *const tmpFileName = @"tmp.der";
         {
             
             if (![[CheckAccessToServer sharedManager] isTemporalCertificateTrusted]) {
-                [self retry:nil];
+                [self initParemetersAndRetryOpenLink];
             }
         }
     }
@@ -476,6 +477,10 @@ static NSString *const tmpFileName = @"tmp.der";
  *  This method repeat the original request that shown the initial UIWebView
  */
 - (IBAction)retry:(id)sender {
+    [self initParemetersAndRetryOpenLink];
+}
+
+- (void) initParemetersAndRetryOpenLink {
     self.isCredentialsWritten = NO;
     self.user = nil;
     self.password = nil;

--- a/Owncloud iOs Client/Login/SSO/SSOViewController.m
+++ b/Owncloud iOs Client/Login/SSO/SSOViewController.m
@@ -219,7 +219,6 @@ static NSString *const tmpFileName = @"tmp.der";
     DLog(@"An error happened during load: %@", error);
     
     if ([error code] != -999) {
-        [_activity stopAnimating];
         [_webView setHidden:NO];
     }
     
@@ -235,7 +234,6 @@ static NSString *const tmpFileName = @"tmp.der";
                 [self askToAcceptCertificate];
             }
           
-
         }
     }
 }
@@ -400,11 +398,26 @@ static NSString *const tmpFileName = @"tmp.der";
     DLog(@"Error connection: %@", error);
     
     //Too many HTTP redirects error. This error happens sometimes.
-    if (error.code == -1007) {
+    if (error.code == kCFURLErrorHTTPTooManyRedirects) {
         UIAlertView *alert = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"unknow_response_server", nil) message:NSLocalizedString(@"", nil) delegate:nil cancelButtonTitle:NSLocalizedString(@"ok", nil) otherButtonTitles:nil];
         [alert show];
         [self retry:nil];
+        
+    } else if ([error.domain isEqualToString: NSURLErrorDomain]) {
+        
+        if (error.code == kCFURLErrorServerCertificateUntrusted         ||
+            error.code == kCFURLErrorServerCertificateHasBadDate        ||
+            error.code == kCFURLErrorServerCertificateHasUnknownRoot    ||
+            error.code == kCFURLErrorServerCertificateNotYetValid)
+        {
+            
+            if (![[CheckAccessToServer sharedManager] isTemporalCertificateTrusted]) {
+                [self retry:nil];
+            }
+        }
     }
+    
+    
 }
 
 - (BOOL)connectionShouldUseCredentialStorage:(NSURLConnection *)connection;


### PR DESCRIPTION
Retry after redirections. Remain the loading spinner until login view is loaded

Fixes: https://github.com/owncloud/ios/issues/837#issuecomment-301743023