### PR TITLE
Login screen redesign

### DIFF
--- a/Owncloud iOs Client/Branding/Customization.h
+++ b/Owncloud iOs Client/Branding/Customization.h
@@ -130,7 +130,7 @@
 #define k_is_text_login_status_bar_white NO
 
 //Show the help link on login
-#define k_is_shown_help_link_on_login YES
+#define k_is_shown_help_link_on_login NO
 #define k_url_link_on_login @"https://owncloud.com/mobile/new"
 
 //User-Agent, Mozilla/5.0 (iOS) ownCloud-iOS/<appVersion> <ob_customUserAgent>

--- a/Owncloud iOs Client/Branding/Customization.h
+++ b/Owncloud iOs Client/Branding/Customization.h
@@ -130,7 +130,7 @@
 #define k_is_text_login_status_bar_white NO
 
 //Show the help link on login
-#define k_is_shown_help_link_on_login NO
+#define k_is_shown_help_link_on_login YES
 #define k_url_link_on_login @"https://owncloud.com/mobile/new"
 
 //User-Agent, Mozilla/5.0 (iOS) ownCloud-iOS/<appVersion> <ob_customUserAgent>

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -383,8 +383,6 @@ connection_declined  Connection declined by user
             self.imageViewLeftURL.isHidden = true
             self.textFieldURL.isHidden = true
             
-            
-            
         }
         
         let shouldBehiddenUserPassFields = (self.loginMode != .create) ? false : true ;
@@ -427,6 +425,15 @@ connection_declined  Connection declined by user
 
     func showURLStackView(hiddenStatus: Bool) {
         self.urlStackView.isHidden = hiddenStatus
+    }
+    
+
+    func showReloadButtonOnURLInfoStackView(hiddenStatus: Bool) {
+        self.urlInfoStackView.isHidden = hiddenStatus
+    }
+    
+    func showPasswordEyeOnPasswordStackView(hiddenStatus: Bool) {
+        self.urlInfoStackView.isHidden = hiddenStatus
     }
     
     // MARK: dismiss

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -167,6 +167,10 @@ connection_declined  Connection declined by user
         textFieldUsername.delegate = self
         textFieldPassword.delegate = self
         
+        textFieldURL.textColor = UIColor.ofURLUserPassword()
+        textFieldUsername.textColor = UIColor.ofURLUserPassword()
+        textFieldPassword.textColor = UIColor.ofURLUserPassword()
+        
         // Tags for the Next navigation with the keyboard
         self.textFieldURL.tag = 1
         self.textFieldUsername.tag = 2

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -408,6 +408,11 @@ connection_declined  Connection declined by user
         self.setConnectButton(status: false)
         
         self.buttonHelpLink.isHidden = Customization.kIsShownHelpLinkOnLogin() ?  false : true
+        
+        let buttonHelpTitleWithoutAppName = NSLocalizedString(NSLocalizedString("help_link_login", comment: ""), comment: "")
+        let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
+        let buttonHelpTitle = buttonHelpTitleWithoutAppName.replacingOccurrences(of: "$appname", with: appName)
+        self.buttonHelpLink.setTitle(buttonHelpTitle, for: .normal)
 
     }
     

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -838,8 +838,12 @@ connection_declined  Connection declined by user
         
         if(segue.identifier == K.segueId.segueToWebLoginView) {
             
-            let nextViewController = (segue.destination as! WebLoginViewController)
-            nextViewController.serverPath = self.serverURLNormalizer.normalizedURL
+//            let nextViewController = (segue.destination as! WebLoginViewController)
+//            nextViewController.serverPath = self.serverURLNormalizer.normalizedURL
+            
+            let destinationNavigationController = segue.destination as! UINavigationController
+            let targetController = destinationNavigationController.topViewController as! WebLoginViewController
+            targetController.serverPath = self.serverURLNormalizer.normalizedURL
         }
     }
     

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -802,7 +802,6 @@ connection_declined  Connection declined by user
     }
     
     @IBAction func connectButtonTapped(_ sender: Any) {
-        self.setNetworkActivityIndicator(status: true)
         self.startAuthenticationWith(authMethod: self.authMethodToLogin)
     }
     

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -409,7 +409,7 @@ connection_declined  Connection declined by user
         
         self.buttonHelpLink.isHidden = Customization.kIsShownHelpLinkOnLogin() ?  false : true
         
-        let buttonHelpTitleWithoutAppName = NSLocalizedString(NSLocalizedString("help_link_login", comment: ""), comment: "")
+        let buttonHelpTitleWithoutAppName = NSLocalizedString("help_link_login", comment: "")
         let appName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as! String
         let buttonHelpTitle = buttonHelpTitleWithoutAppName.replacingOccurrences(of: "$appname", with: appName)
         self.buttonHelpLink.setTitle(buttonHelpTitle, for: .normal)

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -691,10 +691,13 @@ connection_declined  Connection declined by user
             }
             break
         case TextfieldType.url.rawValue:
-            self.checkCurrentUrl()
+            if textField.text != "" {
+                self.checkCurrentUrl()
+            }else{
+                self.setBasicAuthLoginStackViews(hiddenStatus: true)
+            }
             break
         case TextfieldType.username.rawValue:
-            //TODO
             break
         default:
             break
@@ -840,12 +843,9 @@ connection_declined  Connection declined by user
         
         if(segue.identifier == K.segueId.segueToWebLoginView) {
             
-//            let nextViewController = (segue.destination as! WebLoginViewController)
-//            nextViewController.serverPath = self.serverURLNormalizer.normalizedURL
-            
             let destinationNavigationController = segue.destination as! UINavigationController
             let targetController = destinationNavigationController.topViewController as! WebLoginViewController
-            targetController.serverPath = self.serverURLNormalizer.normalizedURL
+            targetController.serverPath = self.validatedServerURL
         }
     }
     

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -204,6 +204,14 @@ connection_declined  Connection declined by user
     }
 
     
+    public override var preferredStatusBarStyle: UIStatusBarStyle {
+        if Customization.kIsTextLoginStatusBarWhite() {
+            return .lightContent
+        }
+        return .default
+    }
+    
+    
     //MARK: Set up credentials error
 
     func showInitMessageCredentialsErrorIfNeeded() {

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -388,7 +388,7 @@ connection_declined  Connection declined by user
         }
         
         let shouldBehiddenUserPassFields = (self.loginMode != .create) ? false : true ;
-        self.updateUserAndPassFields(hiddenStatus: shouldBehiddenUserPassFields)
+        self.showBasicAuthLoginStackViews(hiddenStatus: shouldBehiddenUserPassFields)
 
 
         self.disableLoginButton()
@@ -406,7 +406,7 @@ connection_declined  Connection declined by user
         self.navigationItem.leftBarButtonItem = cancelButton
     }
     
-    func updateUserAndPassFields(hiddenStatus: Bool) {
+    func showBasicAuthLoginStackViews(hiddenStatus: Bool) {
         
         UIView.animate(withDuration: 0.5, animations: {
             self.usernameStackView.isHidden = hiddenStatus
@@ -425,8 +425,9 @@ connection_declined  Connection declined by user
         }
     }
 
-    
-    
+    func showURLStackView(hiddenStatus: Bool) {
+        self.urlStackView.isHidden = hiddenStatus
+    }
     
     // MARK: dismiss
     func closeLoginView() {
@@ -451,7 +452,6 @@ connection_declined  Connection declined by user
                     print ("error detecting authentication methods")
                     
                 } else if validatedURL != nil {
-                    self.updateUserAndPassFields(hiddenStatus: false) //TEST
 
                     self.updateUIWithNormalizedData(self.serverURLNormalizer)
                     
@@ -465,7 +465,7 @@ connection_declined  Connection declined by user
                     if (self.authMethodToLogin != .NONE) {
                         
                         if (self.authMethodToLogin == .BASIC_HTTP_AUTH) {
-                            self.updateUserAndPassFields(hiddenStatus: false)
+                            self.showBasicAuthLoginStackViews(hiddenStatus: false)
                             self.enableLoginButton()
                         }
                         //else { //TODO: enabledafter enter password and no empty user pass

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -911,13 +911,13 @@ connection_declined  Connection declined by user
                                                 
                                                 self.setNetworkActivityIndicator(status: false)
                                                 
-                                                //TODO: check with https url without prefix, error unsupported URL
-                                                if errorHttp == 0 {
-                                                    //self.setPasswordFooterError(message: NSLocalizedString("", comment: "") )
-                                                    self.setPasswordFooterError(message: "Error with the credentials" )
-                                                } else {
-                                                    self.manageNetworkErrors.manageErrorHttp((errorHttp)!, andErrorConnection: error, andUser: self.user)
-                                                }
+//                                                //TODO: check with https url without prefix, error unsupported URL
+//                                                if errorHttp == 0 {
+//                                                    //self.setPasswordFooterError(message: NSLocalizedString("", comment: "") )
+//                                                    self.setPasswordFooterError(message: "Error with the credentials" )
+//                                                } else {
+//                                                    self.manageNetworkErrors.manageErrorHttp((errorHttp)!, andErrorConnection: error, andUser: self.user)
+//                                                }
                                                 
                                                     
                                                 }

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -395,7 +395,8 @@ connection_declined  Connection declined by user
         
         let shouldBehiddenUserPassFields = (self.loginMode != .create) ? false : true ;
         self.setBasicAuthLoginStackViews(hiddenStatus: shouldBehiddenUserPassFields)
-
+        self.scrollView.backgroundColor = UIColor.ofLoginBackground()
+        self.imageViewLogo.backgroundColor = UIColor.ofLoginTopBackground()
 
         self.setConnectButton(status: false)
         
@@ -788,6 +789,7 @@ connection_declined  Connection declined by user
     
 // MARK: IBActions
     @IBAction func reconnectionButtonTapped(_ sender: Any) {
+        self.dismissKeyboard()
         self.checkCurrentUrl()
     }
     

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -38,6 +38,12 @@ struct K {
 //    case Migrate
 //}
 
+public enum TextfieldType: String {
+    case url = "url"
+    case username = "username"
+    case password = "password"
+}
+
 @objc public enum StateCheckedURL: Int {
     case None
     case TestingConnection
@@ -433,7 +439,7 @@ connection_declined  Connection declined by user
     }
     
     func showPasswordEyeOnPasswordStackView(hiddenStatus: Bool) {
-        self.urlInfoStackView.isHidden = hiddenStatus
+        self.imageViewRightPassword.isHidden = hiddenStatus
     }
     
     // MARK: dismiss
@@ -626,9 +632,27 @@ connection_declined  Connection declined by user
     
 // MARK: textField delegate
     public func textFieldDidEndEditing(_ textField: UITextField) {
-
-       // self.checkCurrentUrl()
         
+        switch textField.restorationIdentifier! {
+        case TextfieldType.password.rawValue:
+            //TODO
+            break
+        case TextfieldType.url.rawValue:
+            self.checkCurrentUrl()
+            break
+        case TextfieldType.username.rawValue:
+            //Todo
+            break
+        default:
+            self.checkCurrentUrl()
+            break
+        }
+    }
+    
+    public func textFieldDidBeginEditing(_ textField: UITextField) {
+        if textField.restorationIdentifier! == TextfieldType.password.rawValue {
+            self.showPasswordEyeOnPasswordStackView(hiddenStatus: false)
+        }
     }
 
 

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -447,7 +447,8 @@ connection_declined  Connection declined by user
                     print ("error detecting authentication methods")
                     
                 } else if validatedURL != nil {
-                    
+                    self.updateUserAndPassFields(hiddenStatus: false) //TEST
+
                     self.updateUIWithNormalizedData(self.serverURLNormalizer)
                     
                     self.setURLFooter(message: "", isType: .None)
@@ -461,16 +462,16 @@ connection_declined  Connection declined by user
                         
                         if (self.authMethodToLogin == .BASIC_HTTP_AUTH) {
                             self.updateUserAndPassFields(hiddenStatus: false)
-                            self.buttonConnect.isEnabled = false
+                            self.enableLoginButton()
                         }
                         //else { //TODO: enabledafter enter password and no empty user pass
-                            self.buttonConnect.isEnabled = true
+                            self.enableLoginButton()
                         //}
                         
                         self.setURLFotterSuccess(oNormalized: self.serverURLNormalizer)
                         
                     } else {
-                        self.buttonConnect.isEnabled = false
+                        self.disableLoginButton()
                         self.manageNetworkErrors.returnErrorMessage(withHttpStatusCode: httpStatusCode, andError: nil)
                     }
                     

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -123,7 +123,19 @@ connection_declined  Connection declined by user
     @IBOutlet var buttonConnect: UIButton!
     @IBOutlet var buttonHelpLink: UIButton!
     
-   // var urlNormalized: String!
+    
+    //StackViews
+    @IBOutlet weak var topInfoStackView: UIStackView!
+    @IBOutlet weak var urlStackView: UIStackView!
+    @IBOutlet weak var urlInfoStackView: UIStackView!
+    @IBOutlet weak var usernameStackView: UIStackView!
+    @IBOutlet weak var passwordStackView: UIStackView!
+    @IBOutlet weak var basicAuthInfoStackView: UIStackView!
+    @IBOutlet weak var connectButtonStackView: UIStackView!
+    @IBOutlet weak var helpButtonStackView: UIStackView!
+    
+    
+    //var urlNormalized: String!
     var validatedServerURL: String!
     var allAvailableAuthMethods = [AuthenticationMethod]()
     var authMethodToLogin: AuthenticationMethod!
@@ -317,7 +329,7 @@ connection_declined  Connection declined by user
     }
     
     private func setConnectButtonStyle(isEnabled: Bool) {
-        self.buttonConnect.layer.cornerRadius = self.buttonConnect.layer.bounds.height / 4
+        self.buttonConnect.layer.cornerRadius = self.buttonConnect.layer.bounds.height / 2
         self.buttonConnect.setTitleColor(UIColor.ofLoginButtonText(), for: .normal)
         
       if isEnabled {
@@ -396,19 +408,11 @@ connection_declined  Connection declined by user
     
     func updateUserAndPassFields(hiddenStatus: Bool) {
         
-        self.imageViewUsername.isHidden = hiddenStatus
-        self.textFieldUsername.isHidden = hiddenStatus
-        self.imageViewLeftPassword.isHidden = hiddenStatus
-        self.textFieldPassword.isHidden = hiddenStatus
-        self.imageViewRightPassword.isHidden = hiddenStatus
-        
-        if hiddenStatus {        //TODO: use constraints dependencies from above field instead,stack
-//
-//            self.buttonConnect.center = self.textFieldUsername.center
-//        } else {
-//            
-//             self.buttonConnect.center = self.textFieldUsername.center
-        }
+        UIView.animate(withDuration: 0.5, animations: {
+            self.usernameStackView.isHidden = hiddenStatus
+            self.passwordStackView.isHidden = hiddenStatus
+            self.basicAuthInfoStackView.isHidden = hiddenStatus
+        })
     }
     
     func updateUIWithNormalizedData(_ oNormalized: ServerURLNormalizer) {

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -156,7 +156,6 @@ connection_declined  Connection declined by user
             //Set background color of company image v
             //status bar k_is_text_login_status_bar_white
             self.setLabelsMessageStyle()
-            self.setConnectButtonStyle(isEnabled: false)
         
         self.initUI()
         
@@ -307,7 +306,17 @@ connection_declined  Connection declined by user
         self.labelPasswordFooter.textColor = UIColor.ofLoginErrorText()
     }
     
-    func setConnectButtonStyle(isEnabled: Bool) {
+    func enableLoginButton() {
+        self.buttonConnect.isEnabled = true
+        self.setConnectButtonStyle(isEnabled: true)
+    }
+    
+    func disableLoginButton() {
+        self.buttonConnect.isEnabled = false
+        self.setConnectButtonStyle(isEnabled: false)
+    }
+    
+    private func setConnectButtonStyle(isEnabled: Bool) {
         self.buttonConnect.layer.cornerRadius = self.buttonConnect.layer.bounds.height / 4
         self.buttonConnect.setTitleColor(UIColor.ofLoginButtonText(), for: .normal)
         
@@ -370,8 +379,7 @@ connection_declined  Connection declined by user
         self.updateUserAndPassFields(hiddenStatus: shouldBehiddenUserPassFields)
 
 
-        self.buttonConnect.isEnabled = false
-        
+        self.disableLoginButton()
         
         self.buttonHelpLink.isHidden = Customization.kIsShownHelpLinkOnLogin() ?  false : true
         

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -171,11 +171,6 @@ connection_declined  Connection declined by user
         textFieldUsername.textColor = UIColor.ofURLUserPassword()
         textFieldPassword.textColor = UIColor.ofURLUserPassword()
         
-        // Tags for the Next navigation with the keyboard
-        self.textFieldURL.tag = 1
-        self.textFieldUsername.tag = 2
-        self.textFieldUsername.tag = 3
-        
         self.showInitMessageCredentialsErrorIfNeeded()
 
         let enabledEditUrlUsernamePassword : Bool = (self.loginMode == .create || self.loginMode == .migrate)
@@ -513,8 +508,6 @@ connection_declined  Connection declined by user
                     print ("error detecting authentication methods")
                     
                 } else if validatedURL != nil {
-
-                    self.updateUIWithNormalizedData(self.serverURLNormalizer)
                     
                     self.setURLFooter(message: "", isType: .None)
                     
@@ -537,9 +530,6 @@ connection_declined  Connection declined by user
                             
                         }
                         
-                        //else { //TODO: enabledafter enter password and no empty user pass
-                        //}
-                        
                         self.setURLFotterSuccess(oNormalized: self.serverURLNormalizer)
                         
                     } else {
@@ -547,6 +537,8 @@ connection_declined  Connection declined by user
                         self.setConnectButton(status: false)
                         self.manageNetworkErrors.returnErrorMessage(withHttpStatusCode: httpStatusCode, andError: nil)
                     }
+                    self.updateUIWithNormalizedData(self.serverURLNormalizer)
+
                     
                 } else {
                     self.setConnectButton(status: false)
@@ -554,6 +546,7 @@ connection_declined  Connection declined by user
                 }
             })
         }
+        self.setNetworkActivityIndicator(status: false)
     }
     
     
@@ -563,12 +556,10 @@ connection_declined  Connection declined by user
         switch authMethod {
 
         case .SAML_WEB_SSO:
-            self.setNetworkActivityIndicator(status: false)
             navigateToSAMLLoginView();
             break
 
         case .BEARER_TOKEN:
-            self.setNetworkActivityIndicator(status: false)
             navigateToOAuthLoginView();
             break
 
@@ -679,7 +670,9 @@ connection_declined  Connection declined by user
     public func showError(_ message: String!) {
         DispatchQueue.main.async {
             self.setURLFooter(message: message, isType: .ErrorNotPossibleConnectToServer)
-            self.setBasicAuthLoginStackViews(hiddenStatus: true)
+            if !self.basicAuthInfoStackView.isHidden {
+                self.setBasicAuthLoginStackViews(hiddenStatus: true)
+            }
         }
     }
     
@@ -746,6 +739,7 @@ connection_declined  Connection declined by user
         }
         return false
     }
+
     
     public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         self.view.endEditing(true)
@@ -842,6 +836,12 @@ connection_declined  Connection declined by user
         }
     }
     
+    @IBAction func editingChanged(_ sender: UITextField) {
+        
+        if self.textFieldUsername.text != ""{
+            self.setConnectButton(status: (sender.text?.characters.count)! > 0)
+        }
+    }
 // MARK: segue
     override public func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -546,7 +546,6 @@ connection_declined  Connection declined by user
                 }
             })
         }
-        self.setNetworkActivityIndicator(status: false)
     }
     
     

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -156,6 +156,7 @@ connection_declined  Connection declined by user
             //Set background color of company image v
             //status bar k_is_text_login_status_bar_white
             self.setLabelsMessageStyle()
+            self.setConnectButtonStyle(isEnabled: false)
         
         self.initUI()
         
@@ -304,6 +305,18 @@ connection_declined  Connection declined by user
         
         self.labelPasswordFooter.backgroundColor = UIColor.clear
         self.labelPasswordFooter.textColor = UIColor.ofLoginErrorText()
+    }
+    
+    func setConnectButtonStyle(isEnabled: Bool) {
+        self.buttonConnect.layer.cornerRadius = self.buttonConnect.layer.bounds.height / 4
+        self.buttonConnect.setTitleColor(UIColor.ofLoginButtonText(), for: .normal)
+        
+      if isEnabled {
+            self.buttonConnect.backgroundColor = UIColor.ofLoginButtonBackground()
+        } else {
+            self.buttonConnect.backgroundColor = UIColor.ofLoginButtonBackground().withAlphaComponent(0.6)
+      }
+
     }
     
     

--- a/Owncloud iOs Client/Login/Login/WebLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/WebLoginViewController.swift
@@ -40,6 +40,7 @@ import Foundation
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        self.cancelButton.title = NSLocalizedString("cancel", comment: "")
         self.webViewLogin.delegate = self
         // Do any additional setup after loading the view.
         

--- a/Owncloud iOs Client/Login/Login/WebLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/WebLoginViewController.swift
@@ -25,7 +25,6 @@ import Foundation
     
     // MARK: IBOutlets
     @IBOutlet var webViewLogin: UIWebView!
-    @IBOutlet var cancelButton: UIBarButtonItem!
     
     @IBAction func cancelButtonTapped(_ sender: Any) {
         self.performCancelButtonTapped()
@@ -40,8 +39,11 @@ import Foundation
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.cancelButton.title = NSLocalizedString("cancel", comment: "")
+        
+        let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.cancelBarButtonPressed))
+        self.navigationItem.leftBarButtonItem = cancelButton
         self.webViewLogin.delegate = self
+        
         // Do any additional setup after loading the view.
         
         //TODO: set branding style navigation bar, cancel item title
@@ -56,6 +58,9 @@ import Foundation
         // Dispose of any resources that can be recreated.
     }
     
+    func cancelBarButtonPressed(){
+        self.dismiss(animated: true, completion: nil)
+    }
     
     func loadWebViewWith (url : URL) {
        

--- a/Owncloud iOs Client/Login/Login/WebLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/WebLoginViewController.swift
@@ -40,6 +40,7 @@ import Foundation
     override func viewDidLoad() {
         super.viewDidLoad()
         self.webViewLogin.delegate = self
+        self.webViewLogin.backgroundColor = UIColor.ofWebViewBackground()
     
         // Do any additional setup after loading the view.
         

--- a/Owncloud iOs Client/Login/Login/WebLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/WebLoginViewController.swift
@@ -20,27 +20,25 @@ import Foundation
 
 @objc class WebLoginViewController: UIViewController, UIWebViewDelegate, UITextFieldDelegate {
 
-    
     var authCode = ""
     
     // MARK: IBOutlets
     @IBOutlet var webViewLogin: UIWebView!
-    
+    @IBOutlet var cancelButton: UIBarButtonItem!
+
     @IBAction func cancelButtonTapped(_ sender: Any) {
         self.performCancelButtonTapped()
+
     }
 
     func performCancelButtonTapped() {
         self.performSegue(withIdentifier: K.unwindId.unwindToMainLoginView, sender: self)
     }
 
-    
     var serverPath: String!
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.cancelBarButtonPressed))
-        self.navigationItem.leftBarButtonItem = cancelButton
         self.webViewLogin.delegate = self
     
         // Do any additional setup after loading the view.
@@ -55,10 +53,6 @@ import Foundation
     override func didReceiveMemoryWarning() {
         super.didReceiveMemoryWarning()
         // Dispose of any resources that can be recreated.
-    }
-    
-    func cancelBarButtonPressed(){
-        self.dismiss(animated: true, completion: nil)
     }
     
     func loadWebViewWith (url : URL) {

--- a/Owncloud iOs Client/Login/Login/WebLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/WebLoginViewController.swift
@@ -39,11 +39,10 @@ import Foundation
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
         let cancelButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(self.cancelBarButtonPressed))
         self.navigationItem.leftBarButtonItem = cancelButton
         self.webViewLogin.delegate = self
-        
+    
         // Do any additional setup after loading the view.
         
         //TODO: set branding style navigation bar, cancel item title

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina5_5" orientation="landscape">
-        <adaptation id="fullscreen"/>
+    <device id="ipad9_7" orientation="landscape">
+        <adaptation id="splitview1_3"/>
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
@@ -17,23 +17,23 @@
                         <viewControllerLayoutGuide type="bottom" id="Nrw-Uw-7nS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dxR-Vh-mRQ">
-                        <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
-                                <rect key="frame" x="7" y="20" width="729" height="394"/>
+                                <rect key="frame" x="7" y="20" width="313" height="748"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
-                                        <rect key="frame" x="0.0" y="0.0" width="729" height="512"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="313" height="512"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
-                                                <rect key="frame" x="0.0" y="0.0" width="729" height="200"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="313" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="yIK-Tu-q6d" userLabel="LoginStackView">
-                                                <rect key="frame" x="32" y="200" width="665" height="312"/>
+                                                <rect key="frame" x="16" y="200" width="281" height="312"/>
                                                 <subviews>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC" userLabel="TopInfoStackView">
-                                                        <rect key="frame" x="0.0" y="0.0" width="665" height="25"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ayY-vm-DIf" userLabel="Image Top Info">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -43,7 +43,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="MFx-C4-5pN" userLabel="Label Top Info">
-                                                                <rect key="frame" x="33" y="0.0" width="632" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -51,19 +51,19 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2" userLabel="URLStackView">
-                                                        <rect key="frame" x="0.0" y="41" width="665" height="25"/>
+                                                        <rect key="frame" x="0.0" y="41" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="599" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="640" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="25" id="uI9-CC-Mzh"/>
                                                                 </constraints>
@@ -75,7 +75,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf" userLabel="URLInfoStackView">
-                                                        <rect key="frame" x="0.0" y="82" width="665" height="25"/>
+                                                        <rect key="frame" x="0.0" y="82" width="281" height="25"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gJX-YZ-wjT">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -105,13 +105,13 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="599" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="640" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="g7S-dq-MGB"/>
                                                                     <constraint firstAttribute="width" constant="25" id="qNr-gK-AbW"/>
@@ -124,7 +124,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G" userLabel="UsernameStackView">
-                                                        <rect key="frame" x="0.0" y="123" width="665" height="25"/>
+                                                        <rect key="frame" x="0.0" y="123" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -134,7 +134,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="username" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
-                                                                <rect key="frame" x="33" y="0.0" width="632" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
@@ -142,7 +142,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2" userLabel="PasswordStackView">
-                                                        <rect key="frame" x="0.0" y="164" width="665" height="25"/>
+                                                        <rect key="frame" x="0.0" y="164" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -152,13 +152,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="599" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                                             </textField>
                                                             <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
-                                                                <rect key="frame" x="640" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="Mix-F4-13T"/>
                                                                 </constraints>
@@ -166,7 +166,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kY0-Md-FsP" userLabel="BasicAuthInfoStackVIew">
-                                                        <rect key="frame" x="0.0" y="205" width="665" height="25"/>
+                                                        <rect key="frame" x="0.0" y="205" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BJX-bG-Oio" userLabel="Image View Password Footer">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -176,7 +176,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="BEf-3f-TPh" userLabel="Label Password Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="632" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -184,10 +184,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF" userLabel="ButtonConnectStackView">
-                                                        <rect key="frame" x="0.0" y="246" width="665" height="25"/>
+                                                        <rect key="frame" x="0.0" y="246" width="281" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="665" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
                                                                 <state key="normal" title="Connect"/>
                                                                 <connections>
                                                                     <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
@@ -196,10 +196,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1" userLabel="ButtonHelpStackView">
-                                                        <rect key="frame" x="0.0" y="287" width="665" height="25"/>
+                                                        <rect key="frame" x="0.0" y="287" width="281" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="665" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
                                                                 <state key="normal" title="Button url help link"/>
                                                                 <connections>
                                                                     <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
@@ -316,16 +316,16 @@
                         <viewControllerLayoutGuide type="bottom" id="XkD-Kd-VX0"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="T26-kj-Ka7">
-                        <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
-                                <rect key="frame" x="0.0" y="44" width="736" height="370"/>
+                                <rect key="frame" x="0.0" y="44" width="320" height="724"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-q5-DCr">
-                                <rect key="frame" x="0.0" y="0.0" width="736" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem id="Srt-MH-Z13">

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -103,9 +103,9 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                <rect key="frame" x="133" y="427" width="53" height="30"/>
+                                <rect key="frame" x="24" y="427" width="279" height="30"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button Connect"/>
+                                <state key="normal" title="Connect"/>
                                 <connections>
                                     <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
                                 </connections>
@@ -148,7 +148,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1kC-5M-QFu" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="8" y="30"/>
+            <point key="canvasLocation" x="7.5" y="29.577464788732396"/>
         </scene>
         <!--Basic Login View Controller-->
         <scene sceneID="0pK-kB-OY3">

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_0" orientation="landscape">
+    <device id="ipad9_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -17,23 +17,23 @@
                         <viewControllerLayoutGuide type="bottom" id="Nrw-Uw-7nS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dxR-Vh-mRQ">
-                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
-                                <rect key="frame" x="8" y="20" width="552" height="300"/>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
+                                <rect key="frame" x="7" y="20" width="761" height="1004"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
-                                        <rect key="frame" x="0.0" y="0.0" width="552" height="512"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="752" height="512"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
-                                                <rect key="frame" x="0.0" y="0.0" width="552" height="200"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="752" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="yIK-Tu-q6d" userLabel="LoginStackView">
-                                                <rect key="frame" x="0.0" y="200" width="552" height="312"/>
+                                                <rect key="frame" x="0.0" y="200" width="752" height="312"/>
                                                 <subviews>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC" userLabel="TopInfoStackView">
-                                                        <rect key="frame" x="0.0" y="0.0" width="58" height="25"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="752" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ayY-vm-DIf" userLabel="Image Top Info">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -42,8 +42,8 @@
                                                                     <constraint firstAttribute="height" constant="25" id="tk8-nE-8MI"/>
                                                                 </constraints>
                                                             </imageView>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UMG-rI-qTw" userLabel="Label Top Info">
-                                                                <rect key="frame" x="33" y="0.0" width="25" height="25"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="MFx-C4-5pN" userLabel="Label Top Info">
+                                                                <rect key="frame" x="33" y="0.0" width="719" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -51,19 +51,19 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2" userLabel="URLStackView">
-                                                        <rect key="frame" x="0.0" y="41" width="552" height="25"/>
+                                                        <rect key="frame" x="0.0" y="41" width="752" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="486" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="686" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="527" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="727" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="25" id="zag-UY-pi0"/>
                                                                 </constraints>
@@ -75,7 +75,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf" userLabel="URLInfoStackView">
-                                                        <rect key="frame" x="0.0" y="82" width="58" height="25"/>
+                                                        <rect key="frame" x="0.0" y="82" width="752" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="w1a-U9-TaZ" userLabel="Image View URL Footer">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -84,8 +84,8 @@
                                                                     <constraint firstAttribute="width" constant="25" id="vSb-FK-Xp3"/>
                                                                 </constraints>
                                                             </imageView>
-                                                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ng2-Du-gwx" userLabel="Label URL Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="25" height="25"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
+                                                                <rect key="frame" x="33" y="0.0" width="719" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -93,7 +93,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G" userLabel="UsernameStackView">
-                                                        <rect key="frame" x="0.0" y="123" width="552" height="25"/>
+                                                        <rect key="frame" x="0.0" y="123" width="752" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -103,7 +103,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
-                                                                <rect key="frame" x="33" y="0.0" width="519" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="719" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
@@ -111,7 +111,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2" userLabel="PasswordStackView">
-                                                        <rect key="frame" x="0.0" y="164" width="552" height="25"/>
+                                                        <rect key="frame" x="0.0" y="164" width="752" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -121,13 +121,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="486" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="686" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
-                                                                <rect key="frame" x="527" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="727" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="Mix-F4-13T"/>
                                                                     <constraint firstAttribute="width" constant="25" id="tGK-e9-qDL"/>
@@ -136,7 +136,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kY0-Md-FsP" userLabel="BasicAuthInfoStackVIew">
-                                                        <rect key="frame" x="0.0" y="205" width="58" height="25"/>
+                                                        <rect key="frame" x="0.0" y="205" width="752" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BJX-bG-Oio" userLabel="Image View Password Footer">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -145,8 +145,8 @@
                                                                     <constraint firstAttribute="width" constant="25" id="WXd-sR-TTL"/>
                                                                 </constraints>
                                                             </imageView>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cMk-he-xem" userLabel="Label Password Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="25" height="25"/>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="BEf-3f-TPh" userLabel="Label Password Footer">
+                                                                <rect key="frame" x="33" y="0.0" width="719" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -154,10 +154,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF" userLabel="ButtonConnectStackView">
-                                                        <rect key="frame" x="0.0" y="246" width="552" height="25"/>
+                                                        <rect key="frame" x="0.0" y="246" width="752" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="552" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="752" height="25"/>
                                                                 <state key="normal" title="Connect"/>
                                                                 <connections>
                                                                     <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
@@ -166,10 +166,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1" userLabel="ButtonHelpStackView">
-                                                        <rect key="frame" x="0.0" y="287" width="552" height="25"/>
+                                                        <rect key="frame" x="0.0" y="287" width="752" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="552" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="752" height="25"/>
                                                                 <state key="normal" title="Button url help link"/>
                                                                 <connections>
                                                                     <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
@@ -180,8 +180,11 @@
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstItem="wsI-KP-W6G" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="506-dZ-atv"/>
+                                                    <constraint firstItem="cOi-fS-vwf" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="56u-Ip-oQ5"/>
                                                     <constraint firstItem="EnR-aJ-yK2" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="C4X-0E-Kcq"/>
                                                     <constraint firstItem="g4K-Wc-Pa1" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="UF0-w7-7Mr"/>
+                                                    <constraint firstItem="HZa-qF-5hC" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="gGt-YV-agI"/>
+                                                    <constraint firstItem="kY0-Md-FsP" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="hkZ-cF-43v"/>
                                                     <constraint firstItem="VCQ-68-5UF" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="rfs-ac-4Bx"/>
                                                     <constraint firstItem="2BO-Lb-oZ2" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="ukJ-z7-flU"/>
                                                 </constraints>
@@ -194,8 +197,9 @@
                                     </stackView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="UTQ-pq-jrl" secondAttribute="bottom" id="5B3-jr-Ymk"/>
-                                    <constraint firstItem="UTQ-pq-jrl" firstAttribute="width" secondItem="6mr-Qy-Np8" secondAttribute="width" id="LD0-4c-Ri8"/>
+                                    <constraint firstAttribute="bottom" secondItem="UTQ-pq-jrl" secondAttribute="bottom" constant="36" id="5B3-jr-Ymk"/>
+                                    <constraint firstItem="UTQ-pq-jrl" firstAttribute="width" secondItem="6mr-Qy-Np8" secondAttribute="width" constant="-9" id="LD0-4c-Ri8"/>
+                                    <constraint firstAttribute="trailing" secondItem="UTQ-pq-jrl" secondAttribute="trailing" constant="9" id="P8L-sU-4qh"/>
                                     <constraint firstItem="UTQ-pq-jrl" firstAttribute="top" secondItem="6mr-Qy-Np8" secondAttribute="top" id="XlW-Es-bZw"/>
                                     <constraint firstItem="UTQ-pq-jrl" firstAttribute="leading" secondItem="6mr-Qy-Np8" secondAttribute="leading" id="ZPo-8O-Wjt"/>
                                 </constraints>
@@ -203,10 +207,10 @@
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
-                            <constraint firstAttribute="trailing" secondItem="6mr-Qy-Np8" secondAttribute="trailing" constant="8" id="284-pb-CAm"/>
+                            <constraint firstAttribute="trailing" secondItem="6mr-Qy-Np8" secondAttribute="trailing" id="284-pb-CAm"/>
                             <constraint firstItem="6mr-Qy-Np8" firstAttribute="top" secondItem="Wlp-fe-Gsf" secondAttribute="bottom" id="Khe-DA-eVr"/>
                             <constraint firstItem="Nrw-Uw-7nS" firstAttribute="top" secondItem="6mr-Qy-Np8" secondAttribute="bottom" id="lkv-6h-rV1"/>
-                            <constraint firstItem="6mr-Qy-Np8" firstAttribute="leading" secondItem="dxR-Vh-mRQ" secondAttribute="leading" constant="8" id="vIh-rd-nk7"/>
+                            <constraint firstItem="6mr-Qy-Np8" firstAttribute="leading" secondItem="dxR-Vh-mRQ" secondAttribute="leading" constant="7" id="vIh-rd-nk7"/>
                         </constraints>
                     </view>
                     <connections>
@@ -224,9 +228,9 @@
                         <outlet property="imageViewTopInfo" destination="ayY-vm-DIf" id="E1T-Qe-M8b"/>
                         <outlet property="imageViewURLFooter" destination="w1a-U9-TaZ" id="G2d-FG-Lo1"/>
                         <outlet property="imageViewUsername" destination="TgF-b1-q7W" id="k70-cZ-xoz"/>
-                        <outlet property="labelPasswordFooter" destination="cMk-he-xem" id="Cnj-j4-7Rl"/>
-                        <outlet property="labelTopInfo" destination="UMG-rI-qTw" id="TRB-Ct-Jtf"/>
-                        <outlet property="labelURLFooter" destination="ng2-Du-gwx" id="p1k-YG-5WB"/>
+                        <outlet property="labelPasswordFooter" destination="BEf-3f-TPh" id="BeU-AJ-PUg"/>
+                        <outlet property="labelTopInfo" destination="MFx-C4-5pN" id="B4K-w2-Eih"/>
+                        <outlet property="labelURLFooter" destination="0NZ-MO-sTX" id="jj0-f6-6xb"/>
                         <outlet property="passwordStackView" destination="2BO-Lb-oZ2" id="0iH-UQ-thG"/>
                         <outlet property="textFieldPassword" destination="3io-Sx-qiv" id="Kf4-lG-kZ3"/>
                         <outlet property="textFieldURL" destination="K3Y-mX-EWx" id="evx-Ry-FVD"/>
@@ -240,7 +244,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1kC-5M-QFu" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-50" y="-8"/>
+            <point key="canvasLocation" x="-50.9765625" y="-9.2240117130307464"/>
         </scene>
         <!--Basic Login View Controller-->
         <scene sceneID="0pK-kB-OY3">
@@ -251,7 +255,7 @@
                         <viewControllerLayoutGuide type="bottom" id="8vk-wX-RyQ"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="4sS-h1-K1u">
-                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sRS-t9-TB6" userLabel="Image View Logo">
@@ -338,16 +342,16 @@
                         <viewControllerLayoutGuide type="bottom" id="XkD-Kd-VX0"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="T26-kj-Ka7">
-                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
-                                <rect key="frame" x="0.0" y="44" width="568" height="276"/>
+                                <rect key="frame" x="0.0" y="44" width="768" height="980"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-q5-DCr">
-                                <rect key="frame" x="0.0" y="0.0" width="568" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem id="Srt-MH-Z13">

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -20,110 +20,194 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
-                                <rect key="frame" x="0.0" y="66" width="320" height="128"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                            </imageView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ayY-vm-DIf" userLabel="Image Top Info">
-                                <rect key="frame" x="24" y="195" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UMG-rI-qTw" userLabel="Label Top Info">
-                                <rect key="frame" x="57" y="192" width="206" height="32"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
-                                <rect key="frame" x="24" y="236" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                            </imageView>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                <rect key="frame" x="57" y="233" width="206" height="30"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                <rect key="frame" x="271" y="236" width="32" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button" image="ReconnectIcon.png"/>
-                                <connections>
-                                    <action selector="reconnectionButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="71L-sL-XqG"/>
-                                </connections>
-                            </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="w1a-U9-TaZ" userLabel="Image View URL Footer">
-                                <rect key="frame" x="24" y="272" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ng2-Du-gwx" userLabel="Label URL Footer">
-                                <rect key="frame" x="57" y="269" width="206" height="32"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
-                                <rect key="frame" x="24" y="312" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                            </imageView>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
-                                <rect key="frame" x="57" y="312" width="206" height="30"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
-                                <rect key="frame" x="24" y="352" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                            </imageView>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                <rect key="frame" x="57" y="347" width="206" height="30"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
-                                <rect key="frame" x="271" y="350" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxY="YES"/>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cMk-he-xem" userLabel="Label Password Footer">
-                                <rect key="frame" x="57" y="382" width="206" height="32"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BJX-bG-Oio" userLabel="Image View Password Footer">
-                                <rect key="frame" x="24" y="385" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxY="YES"/>
-                            </imageView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                <rect key="frame" x="24" y="427" width="279" height="30"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Connect"/>
-                                <connections>
-                                    <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
-                                </connections>
-                            </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
-                                <rect key="frame" x="123" y="478" width="74" height="30"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button url help link"/>
-                                <connections>
-                                    <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
-                                </connections>
-                            </button>
-                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Iv-9V-tD4">
-                                <rect key="frame" x="52" y="549" width="200" height="110"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </stackView>
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
+                                <rect key="frame" x="8" y="20" width="552" height="300"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
+                                        <rect key="frame" x="0.0" y="0.0" width="304" height="512"/>
+                                        <subviews>
+                                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
+                                                <rect key="frame" x="0.0" y="0.0" width="304" height="200"/>
+                                            </imageView>
+                                            <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="yIK-Tu-q6d" userLabel="LoginStackView">
+                                                <rect key="frame" x="0.0" y="200" width="304" height="312"/>
+                                                <subviews>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC">
+                                                        <rect key="frame" x="0.0" y="0.0" width="58" height="25"/>
+                                                        <subviews>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ayY-vm-DIf" userLabel="Image Top Info">
+                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="25" id="Crb-ea-czO"/>
+                                                                    <constraint firstAttribute="height" constant="25" id="tk8-nE-8MI"/>
+                                                                </constraints>
+                                                            </imageView>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UMG-rI-qTw" userLabel="Label Top Info">
+                                                                <rect key="frame" x="33" y="0.0" width="25" height="25"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2">
+                                                        <rect key="frame" x="0.0" y="41" width="304" height="25"/>
+                                                        <subviews>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
+                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                            </imageView>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
+                                                                <rect key="frame" x="33" y="0.0" width="238" height="25"/>
+                                                                <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
+                                                                <rect key="frame" x="279" y="0.0" width="25" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="25" id="zag-UY-pi0"/>
+                                                                </constraints>
+                                                                <state key="normal" title="Button" image="ReconnectIcon.png"/>
+                                                                <connections>
+                                                                    <action selector="reconnectionButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="71L-sL-XqG"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf">
+                                                        <rect key="frame" x="0.0" y="82" width="58" height="25"/>
+                                                        <subviews>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="w1a-U9-TaZ" userLabel="Image View URL Footer">
+                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="25" id="nZN-1F-UJd"/>
+                                                                    <constraint firstAttribute="width" constant="25" id="vSb-FK-Xp3"/>
+                                                                </constraints>
+                                                            </imageView>
+                                                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ng2-Du-gwx" userLabel="Label URL Footer">
+                                                                <rect key="frame" x="33" y="0.0" width="25" height="25"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G">
+                                                        <rect key="frame" x="0.0" y="123" width="304" height="25"/>
+                                                        <subviews>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
+                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="25" id="7B2-ec-pt4"/>
+                                                                    <constraint firstAttribute="height" constant="25" id="ceD-ec-4ry"/>
+                                                                </constraints>
+                                                            </imageView>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
+                                                                <rect key="frame" x="33" y="0.0" width="271" height="25"/>
+                                                                <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2">
+                                                        <rect key="frame" x="0.0" y="164" width="304" height="25"/>
+                                                        <subviews>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
+                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="25" id="EEH-Ml-mm9"/>
+                                                                    <constraint firstAttribute="height" constant="25" id="tBm-nZ-Wff"/>
+                                                                </constraints>
+                                                            </imageView>
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
+                                                                <rect key="frame" x="33" y="0.0" width="238" height="25"/>
+                                                                <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                                                <textInputTraits key="textInputTraits"/>
+                                                            </textField>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
+                                                                <rect key="frame" x="279" y="0.0" width="25" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="25" id="Mix-F4-13T"/>
+                                                                    <constraint firstAttribute="width" constant="25" id="tGK-e9-qDL"/>
+                                                                </constraints>
+                                                            </imageView>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kY0-Md-FsP">
+                                                        <rect key="frame" x="0.0" y="205" width="58" height="25"/>
+                                                        <subviews>
+                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BJX-bG-Oio" userLabel="Image View Password Footer">
+                                                                <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="height" constant="25" id="TNo-aG-7Gs"/>
+                                                                    <constraint firstAttribute="width" constant="25" id="WXd-sR-TTL"/>
+                                                                </constraints>
+                                                            </imageView>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" horizontalCompressionResistancePriority="751" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cMk-he-xem" userLabel="Label Password Footer">
+                                                                <rect key="frame" x="33" y="0.0" width="25" height="25"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="13"/>
+                                                                <nil key="textColor"/>
+                                                                <nil key="highlightedColor"/>
+                                                            </label>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF">
+                                                        <rect key="frame" x="0.0" y="246" width="304" height="25"/>
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
+                                                                <rect key="frame" x="0.0" y="0.0" width="304" height="25"/>
+                                                                <state key="normal" title="Connect"/>
+                                                                <connections>
+                                                                    <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                    </stackView>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1">
+                                                        <rect key="frame" x="0.0" y="287" width="304" height="25"/>
+                                                        <subviews>
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
+                                                                <rect key="frame" x="0.0" y="0.0" width="304" height="25"/>
+                                                                <state key="normal" title="Button url help link"/>
+                                                                <connections>
+                                                                    <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
+                                                                </connections>
+                                                            </button>
+                                                        </subviews>
+                                                    </stackView>
+                                                </subviews>
+                                                <constraints>
+                                                    <constraint firstItem="wsI-KP-W6G" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="506-dZ-atv"/>
+                                                    <constraint firstItem="EnR-aJ-yK2" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="C4X-0E-Kcq"/>
+                                                    <constraint firstItem="g4K-Wc-Pa1" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="UF0-w7-7Mr"/>
+                                                    <constraint firstItem="VCQ-68-5UF" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="rfs-ac-4Bx"/>
+                                                    <constraint firstItem="2BO-Lb-oZ2" firstAttribute="width" secondItem="yIK-Tu-q6d" secondAttribute="width" id="ukJ-z7-flU"/>
+                                                </constraints>
+                                            </stackView>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="yIK-Tu-q6d" firstAttribute="width" secondItem="UTQ-pq-jrl" secondAttribute="width" id="Kbe-5c-hoh"/>
+                                            <constraint firstAttribute="trailing" secondItem="e8b-Rl-Mh0" secondAttribute="trailing" id="lNO-ao-ICs"/>
+                                        </constraints>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="bottom" secondItem="UTQ-pq-jrl" secondAttribute="bottom" id="5B3-jr-Ymk"/>
+                                    <constraint firstItem="UTQ-pq-jrl" firstAttribute="width" secondItem="6mr-Qy-Np8" secondAttribute="width" id="LD0-4c-Ri8"/>
+                                    <constraint firstItem="UTQ-pq-jrl" firstAttribute="top" secondItem="6mr-Qy-Np8" secondAttribute="top" id="XlW-Es-bZw"/>
+                                    <constraint firstItem="UTQ-pq-jrl" firstAttribute="leading" secondItem="6mr-Qy-Np8" secondAttribute="leading" id="ZPo-8O-Wjt"/>
+                                </constraints>
+                            </scrollView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="6mr-Qy-Np8" secondAttribute="trailing" constant="8" id="284-pb-CAm"/>
+                            <constraint firstItem="6mr-Qy-Np8" firstAttribute="top" secondItem="Wlp-fe-Gsf" secondAttribute="bottom" id="Khe-DA-eVr"/>
+                            <constraint firstItem="Nrw-Uw-7nS" firstAttribute="top" secondItem="6mr-Qy-Np8" secondAttribute="bottom" id="lkv-6h-rV1"/>
+                            <constraint firstItem="6mr-Qy-Np8" firstAttribute="leading" secondItem="dxR-Vh-mRQ" secondAttribute="leading" constant="8" id="vIh-rd-nk7"/>
+                        </constraints>
                     </view>
                     <connections>
                         <outlet property="buttonConnect" destination="qcz-FW-RTp" id="lkF-6G-Pnj"/>
@@ -148,7 +232,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1kC-5M-QFu" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="7.5" y="29.577464788732396"/>
+            <point key="canvasLocation" x="-50" y="-8"/>
         </scene>
         <!--Basic Login View Controller-->
         <scene sceneID="0pK-kB-OY3">
@@ -197,10 +281,15 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Button url help link"/>
                             </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="WHQ-6J-g5L" userLabel="Image View Server url">
+                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ClQ-UI-2sV">
                                 <rect key="frame" x="44" y="237" width="25" height="25"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </imageView>
+                                <subviews>
+                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="WHQ-6J-g5L" userLabel="Image View Server url">
+                                        <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                    </imageView>
+                                </subviews>
+                            </stackView>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="yFH-v1-5f3" userLabel="Image View Server url">
                                 <rect key="frame" x="44" y="318" width="25" height="25"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="ipad9_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
+    <device id="ipad9_7" orientation="landscape">
+        <adaptation id="splitview1_3"/>
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
@@ -17,23 +17,23 @@
                         <viewControllerLayoutGuide type="bottom" id="Nrw-Uw-7nS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dxR-Vh-mRQ">
-                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
-                                <rect key="frame" x="7" y="20" width="761" height="1004"/>
+                                <rect key="frame" x="7" y="20" width="313" height="748"/>
                                 <subviews>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
-                                        <rect key="frame" x="0.0" y="0.0" width="752" height="512"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
+                                        <rect key="frame" x="0.0" y="0.0" width="313" height="512"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
-                                                <rect key="frame" x="0.0" y="0.0" width="752" height="200"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="313" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="yIK-Tu-q6d" userLabel="LoginStackView">
-                                                <rect key="frame" x="0.0" y="200" width="752" height="312"/>
+                                                <rect key="frame" x="16" y="200" width="281" height="312"/>
                                                 <subviews>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC" userLabel="TopInfoStackView">
-                                                        <rect key="frame" x="0.0" y="0.0" width="752" height="25"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ayY-vm-DIf" userLabel="Image Top Info">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -43,7 +43,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="MFx-C4-5pN" userLabel="Label Top Info">
-                                                                <rect key="frame" x="33" y="0.0" width="719" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -51,19 +51,19 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2" userLabel="URLStackView">
-                                                        <rect key="frame" x="0.0" y="41" width="752" height="25"/>
+                                                        <rect key="frame" x="0.0" y="41" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="686" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="727" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="25" id="uI9-CC-Mzh"/>
                                                                 </constraints>
@@ -75,7 +75,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf" userLabel="URLInfoStackView">
-                                                        <rect key="frame" x="0.0" y="82" width="752" height="25"/>
+                                                        <rect key="frame" x="0.0" y="82" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="w1a-U9-TaZ" userLabel="Image View URL Footer">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -85,15 +85,16 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="686" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="727" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" constant="25" id="zag-UY-pi0"/>
+                                                                    <constraint firstAttribute="height" constant="25" id="g7S-dq-MGB"/>
+                                                                    <constraint firstAttribute="width" constant="25" id="hD6-Ut-R80"/>
                                                                 </constraints>
                                                                 <state key="normal" title="Button" image="ReconnectIcon.png"/>
                                                                 <connections>
@@ -103,7 +104,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G" userLabel="UsernameStackView">
-                                                        <rect key="frame" x="0.0" y="123" width="752" height="25"/>
+                                                        <rect key="frame" x="0.0" y="123" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -113,7 +114,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="username" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
-                                                                <rect key="frame" x="33" y="0.0" width="719" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
@@ -121,7 +122,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2" userLabel="PasswordStackView">
-                                                        <rect key="frame" x="0.0" y="164" width="752" height="25"/>
+                                                        <rect key="frame" x="0.0" y="164" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -131,22 +132,21 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="686" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                                             </textField>
                                                             <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
-                                                                <rect key="frame" x="727" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="Mix-F4-13T"/>
-                                                                    <constraint firstAttribute="width" constant="25" id="tGK-e9-qDL"/>
                                                                 </constraints>
                                                             </imageView>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kY0-Md-FsP" userLabel="BasicAuthInfoStackVIew">
-                                                        <rect key="frame" x="0.0" y="205" width="752" height="25"/>
+                                                        <rect key="frame" x="0.0" y="205" width="281" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BJX-bG-Oio" userLabel="Image View Password Footer">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -156,7 +156,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="BEf-3f-TPh" userLabel="Label Password Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="719" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -164,10 +164,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF" userLabel="ButtonConnectStackView">
-                                                        <rect key="frame" x="0.0" y="246" width="752" height="25"/>
+                                                        <rect key="frame" x="0.0" y="246" width="281" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="752" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
                                                                 <state key="normal" title="Connect"/>
                                                                 <connections>
                                                                     <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
@@ -176,10 +176,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1" userLabel="ButtonHelpStackView">
-                                                        <rect key="frame" x="0.0" y="287" width="752" height="25"/>
+                                                        <rect key="frame" x="0.0" y="287" width="281" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="752" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
                                                                 <state key="normal" title="Button url help link"/>
                                                                 <connections>
                                                                     <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
@@ -201,15 +201,40 @@
                                             </stackView>
                                         </subviews>
                                         <constraints>
-                                            <constraint firstItem="yIK-Tu-q6d" firstAttribute="width" secondItem="UTQ-pq-jrl" secondAttribute="width" id="Kbe-5c-hoh"/>
-                                            <constraint firstAttribute="trailing" secondItem="e8b-Rl-Mh0" secondAttribute="trailing" id="lNO-ao-ICs"/>
+                                            <constraint firstAttribute="trailing" secondItem="yIK-Tu-q6d" secondAttribute="trailing" constant="64" id="as0-kh-7bM"/>
+                                            <constraint firstAttribute="trailing" secondItem="yIK-Tu-q6d" secondAttribute="trailing" constant="32" id="gYI-an-fUb"/>
+                                            <constraint firstAttribute="trailing" secondItem="yIK-Tu-q6d" secondAttribute="trailing" constant="16" id="zbu-bW-7LZ"/>
                                         </constraints>
+                                        <variation key="default">
+                                            <mask key="constraints">
+                                                <exclude reference="as0-kh-7bM"/>
+                                                <exclude reference="gYI-an-fUb"/>
+                                                <exclude reference="zbu-bW-7LZ"/>
+                                            </mask>
+                                        </variation>
+                                        <variation key="heightClass=compact-widthClass=compact">
+                                            <mask key="constraints">
+                                                <include reference="as0-kh-7bM"/>
+                                                <exclude reference="gYI-an-fUb"/>
+                                            </mask>
+                                        </variation>
+                                        <variation key="heightClass=regular-widthClass=compact">
+                                            <mask key="constraints">
+                                                <include reference="zbu-bW-7LZ"/>
+                                            </mask>
+                                        </variation>
+                                        <variation key="heightClass=regular-widthClass=regular">
+                                            <mask key="constraints">
+                                                <include reference="as0-kh-7bM"/>
+                                            </mask>
+                                        </variation>
                                     </stackView>
                                 </subviews>
                                 <constraints>
                                     <constraint firstAttribute="bottom" secondItem="UTQ-pq-jrl" secondAttribute="bottom" constant="36" id="5B3-jr-Ymk"/>
-                                    <constraint firstItem="UTQ-pq-jrl" firstAttribute="width" secondItem="6mr-Qy-Np8" secondAttribute="width" constant="-9" id="LD0-4c-Ri8"/>
-                                    <constraint firstAttribute="trailing" secondItem="UTQ-pq-jrl" secondAttribute="trailing" constant="9" id="P8L-sU-4qh"/>
+                                    <constraint firstItem="UTQ-pq-jrl" firstAttribute="width" secondItem="6mr-Qy-Np8" secondAttribute="width" id="LD0-4c-Ri8"/>
+                                    <constraint firstAttribute="trailing" secondItem="UTQ-pq-jrl" secondAttribute="trailing" id="P8L-sU-4qh"/>
+                                    <constraint firstItem="e8b-Rl-Mh0" firstAttribute="width" secondItem="6mr-Qy-Np8" secondAttribute="width" id="TV5-X3-25Y"/>
                                     <constraint firstItem="UTQ-pq-jrl" firstAttribute="top" secondItem="6mr-Qy-Np8" secondAttribute="top" id="XlW-Es-bZw"/>
                                     <constraint firstItem="UTQ-pq-jrl" firstAttribute="leading" secondItem="6mr-Qy-Np8" secondAttribute="leading" id="ZPo-8O-Wjt"/>
                                 </constraints>
@@ -227,6 +252,7 @@
                         <outlet property="basicAuthInfoStackView" destination="kY0-Md-FsP" id="6kU-lP-WEK"/>
                         <outlet property="buttonConnect" destination="qcz-FW-RTp" id="lkF-6G-Pnj"/>
                         <outlet property="buttonHelpLink" destination="lUz-8C-zKg" id="gnX-eE-ywn"/>
+                        <outlet property="buttonReconectionURL" destination="eSw-Lz-XIR" id="3Dt-bN-Rtt"/>
                         <outlet property="buttonReconnection" destination="HUS-Qc-A5N" id="c26-Ww-cpG"/>
                         <outlet property="connectButtonStackView" destination="VCQ-68-5UF" id="SSe-hf-90h"/>
                         <outlet property="helpButtonStackView" destination="g4K-Wc-Pa1" id="Vgl-P4-thx"/>
@@ -242,6 +268,7 @@
                         <outlet property="labelTopInfo" destination="MFx-C4-5pN" id="B4K-w2-Eih"/>
                         <outlet property="labelURLFooter" destination="0NZ-MO-sTX" id="jj0-f6-6xb"/>
                         <outlet property="passwordStackView" destination="2BO-Lb-oZ2" id="0iH-UQ-thG"/>
+                        <outlet property="scrollView" destination="6mr-Qy-Np8" id="Mc3-1A-fsR"/>
                         <outlet property="textFieldPassword" destination="3io-Sx-qiv" id="Kf4-lG-kZ3"/>
                         <outlet property="textFieldURL" destination="K3Y-mX-EWx" id="evx-Ry-FVD"/>
                         <outlet property="textFieldUsername" destination="L65-Zl-2qP" id="gQL-J4-iaP"/>
@@ -256,93 +283,6 @@
             </objects>
             <point key="canvasLocation" x="-50.9765625" y="-9.2240117130307464"/>
         </scene>
-        <!--Basic Login View Controller-->
-        <scene sceneID="0pK-kB-OY3">
-            <objects>
-                <viewController id="9eh-Iq-fCh" userLabel="Basic Login View Controller" sceneMemberID="viewController">
-                    <layoutGuides>
-                        <viewControllerLayoutGuide type="top" id="7SQ-KY-yZ0"/>
-                        <viewControllerLayoutGuide type="bottom" id="8vk-wX-RyQ"/>
-                    </layoutGuides>
-                    <view key="view" contentMode="scaleToFill" id="4sS-h1-K1u">
-                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sRS-t9-TB6" userLabel="Image View Logo">
-                                <rect key="frame" x="20" y="71" width="375" height="128"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </imageView>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HO1-6B-WSI" userLabel="Text Field Url">
-                                <rect key="frame" x="77" y="234" width="261" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Gk0-n1-C1O" userLabel="Text Field Username">
-                                <rect key="frame" x="77" y="315" width="261" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="lcy-uW-cEM" userLabel="Text Field Password">
-                                <rect key="frame" x="77" y="355" width="261" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <nil key="textColor"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <textInputTraits key="textInputTraits"/>
-                            </textField>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vC7-3x-4iY">
-                                <rect key="frame" x="153" y="437" width="108" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button Connect"/>
-                            </button>
-                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Z7n-Kc-E6f">
-                                <rect key="frame" x="143" y="508" width="129" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Button url help link"/>
-                            </button>
-                            <stackView opaque="NO" contentMode="scaleToFill" fixedFrame="YES" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="ClQ-UI-2sV">
-                                <rect key="frame" x="44" y="237" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <subviews>
-                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="WHQ-6J-g5L" userLabel="Image View Server url">
-                                        <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
-                                    </imageView>
-                                </subviews>
-                            </stackView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="yFH-v1-5f3" userLabel="Image View Server url">
-                                <rect key="frame" x="44" y="318" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </imageView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="gH2-z0-naB" userLabel="Image View Server url">
-                                <rect key="frame" x="44" y="358" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </imageView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="rhK-Q0-yTm">
-                                <rect key="frame" x="346" y="358" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pe8-bj-WWP" userLabel="Label Server Footer">
-                                <rect key="frame" x="77" y="275" width="261" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <nil key="textColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
-                            <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5Yd-ec-Eiq" userLabel="Image View Server url">
-                                <rect key="frame" x="44" y="279" width="25" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                            </imageView>
-                        </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                    </view>
-                </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="J0P-TE-YCc" userLabel="First Responder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="726" y="519"/>
-        </scene>
         <!--Web Login View Controller-->
         <scene sceneID="aXj-g5-zsT">
             <objects>
@@ -352,16 +292,16 @@
                         <viewControllerLayoutGuide type="bottom" id="XkD-Kd-VX0"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="T26-kj-Ka7">
-                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
+                        <rect key="frame" x="0.0" y="0.0" width="320" height="768"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
-                                <rect key="frame" x="0.0" y="44" width="768" height="980"/>
+                                <rect key="frame" x="0.0" y="44" width="320" height="724"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-q5-DCr">
-                                <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem id="Srt-MH-Z13">

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -21,19 +21,19 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
-                                <rect key="frame" x="7" y="20" width="761" height="1004"/>
+                                <rect key="frame" x="0.0" y="20" width="768" height="1004"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
-                                        <rect key="frame" x="0.0" y="0.0" width="761" height="512"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="768" height="512"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
-                                                <rect key="frame" x="0.0" y="0.0" width="761" height="200"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="768" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="yIK-Tu-q6d" userLabel="LoginStackView">
-                                                <rect key="frame" x="64" y="200" width="633" height="312"/>
+                                                <rect key="frame" x="64" y="200" width="640" height="312"/>
                                                 <subviews>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC" userLabel="TopInfoStackView">
-                                                        <rect key="frame" x="0.0" y="0.0" width="633" height="25"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="640" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ayY-vm-DIf" userLabel="Image Top Info">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -43,7 +43,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="MFx-C4-5pN" userLabel="Label Top Info">
-                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="607" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -51,7 +51,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2" userLabel="URLStackView">
-                                                        <rect key="frame" x="0.0" y="41" width="633" height="25"/>
+                                                        <rect key="frame" x="0.0" y="41" width="640" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -61,13 +61,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="574" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="633" y="0.0" width="0.0" height="25"/>
+                                                                <rect key="frame" x="615" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="d2d-vw-fSp"/>
                                                                     <constraint firstAttribute="width" constant="25" id="uI9-CC-Mzh"/>
@@ -83,7 +83,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf" userLabel="URLInfoStackView">
-                                                        <rect key="frame" x="0.0" y="82" width="633" height="25"/>
+                                                        <rect key="frame" x="0.0" y="82" width="640" height="25"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gJX-YZ-wjT">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -111,13 +111,13 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="574" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="633" y="0.0" width="0.0" height="25"/>
+                                                                <rect key="frame" x="615" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="g7S-dq-MGB"/>
                                                                     <constraint firstAttribute="width" constant="25" id="qNr-gK-AbW"/>
@@ -130,7 +130,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G" userLabel="UsernameStackView">
-                                                        <rect key="frame" x="0.0" y="123" width="633" height="25"/>
+                                                        <rect key="frame" x="0.0" y="123" width="640" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -140,7 +140,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="username" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
-                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="607" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" returnKeyType="next"/>
@@ -148,7 +148,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2" userLabel="PasswordStackView">
-                                                        <rect key="frame" x="0.0" y="164" width="633" height="25"/>
+                                                        <rect key="frame" x="0.0" y="164" width="640" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -158,13 +158,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="574" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                                             </textField>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BR8-xb-EG9">
-                                                                <rect key="frame" x="633" y="0.0" width="0.0" height="25"/>
+                                                                <rect key="frame" x="615" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="25" id="ccj-FV-NUm"/>
                                                                     <constraint firstAttribute="height" constant="25" id="ojW-d0-sXL"/>
@@ -176,7 +176,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kY0-Md-FsP" userLabel="BasicAuthInfoStackVIew">
-                                                        <rect key="frame" x="0.0" y="205" width="633" height="25"/>
+                                                        <rect key="frame" x="0.0" y="205" width="640" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BJX-bG-Oio" userLabel="Image View Password Footer">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -186,7 +186,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="BEf-3f-TPh" userLabel="Label Password Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="607" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -194,10 +194,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF" userLabel="ButtonConnectStackView">
-                                                        <rect key="frame" x="0.0" y="246" width="633" height="25"/>
+                                                        <rect key="frame" x="0.0" y="246" width="640" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="633" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="640" height="25"/>
                                                                 <state key="normal" title="Connect"/>
                                                                 <connections>
                                                                     <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
@@ -206,10 +206,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1" userLabel="ButtonHelpStackView">
-                                                        <rect key="frame" x="0.0" y="287" width="633" height="25"/>
+                                                        <rect key="frame" x="0.0" y="287" width="640" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="633" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="640" height="25"/>
                                                                 <state key="normal" title="Button url help link"/>
                                                                 <connections>
                                                                     <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
@@ -280,7 +280,7 @@
                             <constraint firstAttribute="trailing" secondItem="6mr-Qy-Np8" secondAttribute="trailing" id="284-pb-CAm"/>
                             <constraint firstItem="6mr-Qy-Np8" firstAttribute="top" secondItem="Wlp-fe-Gsf" secondAttribute="bottom" id="Khe-DA-eVr"/>
                             <constraint firstItem="Nrw-Uw-7nS" firstAttribute="top" secondItem="6mr-Qy-Np8" secondAttribute="bottom" id="lkv-6h-rV1"/>
-                            <constraint firstItem="6mr-Qy-Np8" firstAttribute="leading" secondItem="dxR-Vh-mRQ" secondAttribute="leading" constant="7" id="vIh-rd-nk7"/>
+                            <constraint firstItem="6mr-Qy-Np8" firstAttribute="leading" secondItem="dxR-Vh-mRQ" secondAttribute="leading" id="vIh-rd-nk7"/>
                         </constraints>
                     </view>
                     <connections>

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="ipad9_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
+    <device id="ipad12_9" orientation="landscape">
+        <adaptation id="splitview1_3"/>
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
@@ -17,23 +17,38 @@
                         <viewControllerLayoutGuide type="bottom" id="Nrw-Uw-7nS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dxR-Vh-mRQ">
-                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
-                                <rect key="frame" x="0.0" y="20" width="768" height="1004"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="1004"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
-                                        <rect key="frame" x="0.0" y="0.0" width="768" height="512"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="452"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
-                                                <rect key="frame" x="0.0" y="0.0" width="768" height="200"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="375" height="140"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="195" id="CBa-0d-coz"/>
+                                                    <constraint firstAttribute="height" constant="140" id="fzU-20-Who"/>
+                                                </constraints>
+                                                <variation key="default">
+                                                    <mask key="constraints">
+                                                        <exclude reference="CBa-0d-coz"/>
+                                                    </mask>
+                                                </variation>
+                                                <variation key="heightClass=regular-widthClass=regular">
+                                                    <mask key="constraints">
+                                                        <include reference="CBa-0d-coz"/>
+                                                        <exclude reference="fzU-20-Who"/>
+                                                    </mask>
+                                                </variation>
                                             </imageView>
                                             <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="yIK-Tu-q6d" userLabel="LoginStackView">
-                                                <rect key="frame" x="64" y="200" width="640" height="312"/>
+                                                <rect key="frame" x="16" y="140" width="343" height="312"/>
                                                 <subviews>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC" userLabel="TopInfoStackView">
-                                                        <rect key="frame" x="0.0" y="0.0" width="640" height="25"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="343" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ayY-vm-DIf" userLabel="Image Top Info">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -43,7 +58,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="MFx-C4-5pN" userLabel="Label Top Info">
-                                                                <rect key="frame" x="33" y="0.0" width="607" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="310" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -51,7 +66,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2" userLabel="URLStackView">
-                                                        <rect key="frame" x="0.0" y="41" width="640" height="25"/>
+                                                        <rect key="frame" x="0.0" y="41" width="343" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -61,13 +76,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="574" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="310" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="615" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="343" y="0.0" width="0.0" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="d2d-vw-fSp"/>
                                                                     <constraint firstAttribute="width" constant="25" id="uI9-CC-Mzh"/>
@@ -83,7 +98,7 @@
                                                         </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf" userLabel="URLInfoStackView">
-                                                        <rect key="frame" x="0.0" y="82" width="640" height="25"/>
+                                                        <rect key="frame" x="0.0" y="82" width="343" height="25"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gJX-YZ-wjT">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -110,13 +125,13 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="574" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="310" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="615" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="343" y="0.0" width="0.0" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="g7S-dq-MGB"/>
                                                                     <constraint firstAttribute="width" constant="25" id="qNr-gK-AbW"/>
@@ -129,7 +144,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G" userLabel="UsernameStackView">
-                                                        <rect key="frame" x="0.0" y="123" width="640" height="25"/>
+                                                        <rect key="frame" x="0.0" y="123" width="343" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -139,7 +154,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="username" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
-                                                                <rect key="frame" x="33" y="0.0" width="607" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="310" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" returnKeyType="next"/>
@@ -147,7 +162,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2" userLabel="PasswordStackView">
-                                                        <rect key="frame" x="0.0" y="164" width="640" height="25"/>
+                                                        <rect key="frame" x="0.0" y="164" width="343" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -157,13 +172,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="574" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="310" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                                             </textField>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BR8-xb-EG9">
-                                                                <rect key="frame" x="615" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="343" y="0.0" width="0.0" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="25" id="ccj-FV-NUm"/>
                                                                     <constraint firstAttribute="height" constant="25" id="ojW-d0-sXL"/>
@@ -175,7 +190,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kY0-Md-FsP" userLabel="BasicAuthInfoStackVIew">
-                                                        <rect key="frame" x="0.0" y="205" width="640" height="25"/>
+                                                        <rect key="frame" x="0.0" y="205" width="343" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BJX-bG-Oio" userLabel="Image View Password Footer">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -185,7 +200,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="BEf-3f-TPh" userLabel="Label Password Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="607" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="310" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -193,10 +208,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF" userLabel="ButtonConnectStackView">
-                                                        <rect key="frame" x="0.0" y="246" width="640" height="25"/>
+                                                        <rect key="frame" x="0.0" y="246" width="343" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="640" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="25"/>
                                                                 <state key="normal" title="Connect"/>
                                                                 <connections>
                                                                     <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
@@ -205,10 +220,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1" userLabel="ButtonHelpStackView">
-                                                        <rect key="frame" x="0.0" y="287" width="640" height="25"/>
+                                                        <rect key="frame" x="0.0" y="287" width="343" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="640" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="343" height="25"/>
                                                                 <state key="normal" title="Button url help link"/>
                                                                 <connections>
                                                                     <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
@@ -327,11 +342,11 @@
                         <viewControllerLayoutGuide type="bottom" id="XkD-Kd-VX0"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="T26-kj-Ka7">
-                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
-                                <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="1024"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                         </subviews>

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="ipad12_9" orientation="landscape">
-        <adaptation id="splitview1_3"/>
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
@@ -17,11 +17,11 @@
                         <viewControllerLayoutGuide type="bottom" id="Nrw-Uw-7nS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dxR-Vh-mRQ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="1024"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
-                                <rect key="frame" x="0.0" y="20" width="375" height="1004"/>
+                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="452"/>
@@ -75,10 +75,9 @@
                                                                     <constraint firstAttribute="height" constant="25" id="Tw5-wu-tEO"/>
                                                                 </constraints>
                                                             </imageView>
-                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
+                                                            <textField opaque="NO" clipsSubviews="YES" tag="1" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
                                                                 <rect key="frame" x="33" y="0.0" width="310" height="25"/>
                                                                 <nil key="textColor"/>
-                                                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
@@ -153,7 +152,7 @@
                                                                     <constraint firstAttribute="height" constant="25" id="ceD-ec-4ry"/>
                                                                 </constraints>
                                                             </imageView>
-                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="username" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
+                                                            <textField opaque="NO" clipsSubviews="YES" tag="2" contentMode="scaleToFill" restorationIdentifier="username" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
                                                                 <rect key="frame" x="33" y="0.0" width="310" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -171,11 +170,14 @@
                                                                     <constraint firstAttribute="height" constant="25" id="tBm-nZ-Wff"/>
                                                                 </constraints>
                                                             </imageView>
-                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
+                                                            <textField opaque="NO" clipsSubviews="YES" tag="3" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
                                                                 <rect key="frame" x="33" y="0.0" width="310" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
+                                                                <connections>
+                                                                    <action selector="editingChanged:" destination="iPx-pb-eEh" eventType="editingChanged" id="FPe-9o-lti"/>
+                                                                </connections>
                                                             </textField>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BR8-xb-EG9">
                                                                 <rect key="frame" x="343" y="0.0" width="0.0" height="25"/>
@@ -342,11 +344,11 @@
                         <viewControllerLayoutGuide type="bottom" id="XkD-Kd-VX0"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="T26-kj-Ka7">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="1024"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
-                                <rect key="frame" x="0.0" y="0.0" width="375" height="1024"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                         </subviews>
@@ -358,8 +360,15 @@
                             <constraint firstItem="XkD-Kd-VX0" firstAttribute="top" secondItem="qbt-Jk-Nkc" secondAttribute="bottom" id="tWH-TO-pPd"/>
                         </constraints>
                     </view>
-                    <navigationItem key="navigationItem" id="Ixp-d8-gr3"/>
+                    <navigationItem key="navigationItem" id="Ixp-d8-gr3">
+                        <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="HBO-n1-lRI">
+                            <connections>
+                                <action selector="cancelButtonTapped:" destination="f4N-GJ-PQD" id="v5N-Qo-E1z"/>
+                            </connections>
+                        </barButtonItem>
+                    </navigationItem>
                     <connections>
+                        <outlet property="cancelButton" destination="HBO-n1-lRI" id="5NH-EY-BXZ"/>
                         <outlet property="webViewLogin" destination="qbt-Jk-Nkc" id="6yt-1o-xB0"/>
                         <segue destination="gOD-iC-eEd" kind="unwind" identifier="unwindToMainLoginView" unwindAction="unwindToMainLoginViewWithSegue:" id="hoy-NS-fHW"/>
                     </connections>

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="retina4_0" orientation="portrait">
+    <device id="ipad12_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -17,20 +17,20 @@
                         <viewControllerLayoutGuide type="bottom" id="Nrw-Uw-7nS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dxR-Vh-mRQ">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
                                 <rect key="frame" x="8" y="20" width="552" height="300"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
-                                        <rect key="frame" x="0.0" y="0.0" width="304" height="512"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="1008" height="512"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
-                                                <rect key="frame" x="0.0" y="0.0" width="304" height="200"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="1008" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="yIK-Tu-q6d" userLabel="LoginStackView">
-                                                <rect key="frame" x="0.0" y="200" width="304" height="312"/>
+                                                <rect key="frame" x="0.0" y="200" width="1008" height="312"/>
                                                 <subviews>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC">
                                                         <rect key="frame" x="0.0" y="0.0" width="58" height="25"/>
@@ -51,19 +51,19 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2">
-                                                        <rect key="frame" x="0.0" y="41" width="304" height="25"/>
+                                                        <rect key="frame" x="0.0" y="41" width="1008" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="238" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="942" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="279" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="983" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="25" id="zag-UY-pi0"/>
                                                                 </constraints>
@@ -93,7 +93,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G">
-                                                        <rect key="frame" x="0.0" y="123" width="304" height="25"/>
+                                                        <rect key="frame" x="0.0" y="123" width="1008" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -103,7 +103,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
-                                                                <rect key="frame" x="33" y="0.0" width="271" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="975" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
@@ -111,7 +111,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2">
-                                                        <rect key="frame" x="0.0" y="164" width="304" height="25"/>
+                                                        <rect key="frame" x="0.0" y="164" width="1008" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -121,13 +121,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="238" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="942" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
-                                                                <rect key="frame" x="279" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="983" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="Mix-F4-13T"/>
                                                                     <constraint firstAttribute="width" constant="25" id="tGK-e9-qDL"/>
@@ -154,10 +154,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF">
-                                                        <rect key="frame" x="0.0" y="246" width="304" height="25"/>
+                                                        <rect key="frame" x="0.0" y="246" width="1008" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="304" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1008" height="25"/>
                                                                 <state key="normal" title="Connect"/>
                                                                 <connections>
                                                                     <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
@@ -166,10 +166,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1">
-                                                        <rect key="frame" x="0.0" y="287" width="304" height="25"/>
+                                                        <rect key="frame" x="0.0" y="287" width="1008" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="304" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="1008" height="25"/>
                                                                 <state key="normal" title="Button url help link"/>
                                                                 <connections>
                                                                     <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
@@ -243,7 +243,7 @@
                         <viewControllerLayoutGuide type="bottom" id="8vk-wX-RyQ"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="4sS-h1-K1u">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sRS-t9-TB6" userLabel="Image View Logo">
@@ -330,16 +330,16 @@
                         <viewControllerLayoutGuide type="bottom" id="XkD-Kd-VX0"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="T26-kj-Ka7">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
+                        <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
-                                <rect key="frame" x="0.0" y="44" width="320" height="524"/>
+                                <rect key="frame" x="0.0" y="44" width="1024" height="1322"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-q5-DCr">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="1024" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem id="Srt-MH-Z13">

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="ipad9_7" orientation="landscape">
-        <adaptation id="splitview1_3"/>
+    <device id="ipad9_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
@@ -17,23 +17,23 @@
                         <viewControllerLayoutGuide type="bottom" id="Nrw-Uw-7nS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dxR-Vh-mRQ">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
-                                <rect key="frame" x="7" y="20" width="313" height="748"/>
+                                <rect key="frame" x="7" y="20" width="761" height="1004"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
-                                        <rect key="frame" x="0.0" y="0.0" width="313" height="512"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="761" height="512"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
-                                                <rect key="frame" x="0.0" y="0.0" width="313" height="200"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="761" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="yIK-Tu-q6d" userLabel="LoginStackView">
-                                                <rect key="frame" x="16" y="200" width="281" height="312"/>
+                                                <rect key="frame" x="64" y="200" width="633" height="312"/>
                                                 <subviews>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC" userLabel="TopInfoStackView">
-                                                        <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="633" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ayY-vm-DIf" userLabel="Image Top Info">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -43,7 +43,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="MFx-C4-5pN" userLabel="Label Top Info">
-                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -51,20 +51,25 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2" userLabel="URLStackView">
-                                                        <rect key="frame" x="0.0" y="41" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="41" width="633" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="25" id="5h0-h2-6q7"/>
+                                                                    <constraint firstAttribute="height" constant="25" id="Tw5-wu-tEO"/>
+                                                                </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="567" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
+                                                            <button hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
+                                                                <rect key="frame" x="608" y="0.0" width="25" height="25"/>
                                                                 <constraints>
+                                                                    <constraint firstAttribute="height" constant="25" id="d2d-vw-fSp"/>
                                                                     <constraint firstAttribute="width" constant="25" id="uI9-CC-Mzh"/>
                                                                 </constraints>
                                                                 <state key="normal" title="Button" image="ReconnectIcon.png"/>
@@ -73,15 +78,18 @@
                                                                 </connections>
                                                             </button>
                                                         </subviews>
+                                                        <constraints>
+                                                            <constraint firstItem="eSw-Lz-XIR" firstAttribute="leading" secondItem="K3Y-mX-EWx" secondAttribute="trailing" constant="8" id="kNi-X2-HYy"/>
+                                                        </constraints>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf" userLabel="URLInfoStackView">
-                                                        <rect key="frame" x="0.0" y="82" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="82" width="633" height="25"/>
                                                         <subviews>
                                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gJX-YZ-wjT">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
                                                                 <subviews>
-                                                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Gsa-2t-LAX">
-                                                                        <rect key="frame" x="2" y="2" width="20" height="20"/>
+                                                                    <activityIndicatorView hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Gsa-2t-LAX">
+                                                                        <rect key="frame" x="0.0" y="2" width="20" height="20"/>
                                                                     </activityIndicatorView>
                                                                     <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="XqP-Ib-XSt">
                                                                         <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -96,22 +104,20 @@
                                                                     <constraint firstItem="Gsa-2t-LAX" firstAttribute="top" secondItem="gJX-YZ-wjT" secondAttribute="top" constant="2" id="AIY-QL-9Mw"/>
                                                                     <constraint firstAttribute="width" constant="25" id="BfV-EZ-IzJ"/>
                                                                     <constraint firstAttribute="bottom" secondItem="Gsa-2t-LAX" secondAttribute="bottom" constant="3" id="Bjm-7T-tOC"/>
-                                                                    <constraint firstItem="XqP-Ib-XSt" firstAttribute="leading" secondItem="gJX-YZ-wjT" secondAttribute="leading" id="FUK-9i-Rhf"/>
-                                                                    <constraint firstItem="Gsa-2t-LAX" firstAttribute="leading" secondItem="gJX-YZ-wjT" secondAttribute="leading" constant="2" id="Xwz-6a-SOS"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="XqP-Ib-XSt" secondAttribute="trailing" id="aKf-pl-9as"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="Gsa-2t-LAX" secondAttribute="trailing" constant="3" id="dup-4t-mBX"/>
-                                                                    <constraint firstAttribute="bottom" secondItem="XqP-Ib-XSt" secondAttribute="bottom" id="vy8-VL-JiJ"/>
-                                                                    <constraint firstItem="XqP-Ib-XSt" firstAttribute="top" secondItem="gJX-YZ-wjT" secondAttribute="top" id="zs5-3p-Fww"/>
+                                                                    <constraint firstAttribute="height" constant="25" id="Fhz-jE-MKK"/>
+                                                                    <constraint firstItem="XqP-Ib-XSt" firstAttribute="centerY" secondItem="gJX-YZ-wjT" secondAttribute="centerY" id="K5f-On-1Da"/>
+                                                                    <constraint firstItem="XqP-Ib-XSt" firstAttribute="centerX" secondItem="gJX-YZ-wjT" secondAttribute="centerX" id="O6o-cU-EK1"/>
+                                                                    <constraint firstItem="Gsa-2t-LAX" firstAttribute="leading" secondItem="gJX-YZ-wjT" secondAttribute="leading" id="Xwz-6a-SOS"/>
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="567" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
-                                                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
+                                                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
+                                                                <rect key="frame" x="608" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="g7S-dq-MGB"/>
                                                                     <constraint firstAttribute="width" constant="25" id="qNr-gK-AbW"/>
@@ -124,7 +130,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G" userLabel="UsernameStackView">
-                                                        <rect key="frame" x="0.0" y="123" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="123" width="633" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -134,7 +140,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="username" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
-                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
@@ -142,7 +148,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2" userLabel="PasswordStackView">
-                                                        <rect key="frame" x="0.0" y="164" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="164" width="633" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -152,21 +158,25 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="567" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                                             </textField>
-                                                            <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
-                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
+                                                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BR8-xb-EG9">
+                                                                <rect key="frame" x="608" y="0.0" width="25" height="25"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="height" constant="25" id="Mix-F4-13T"/>
+                                                                    <constraint firstAttribute="width" constant="25" id="ccj-FV-NUm"/>
+                                                                    <constraint firstAttribute="height" constant="25" id="ojW-d0-sXL"/>
                                                                 </constraints>
-                                                            </imageView>
+                                                                <connections>
+                                                                    <action selector="revealPasswordButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="SPx-s4-EcT"/>
+                                                                </connections>
+                                                            </button>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kY0-Md-FsP" userLabel="BasicAuthInfoStackVIew">
-                                                        <rect key="frame" x="0.0" y="205" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="205" width="633" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BJX-bG-Oio" userLabel="Image View Password Footer">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -176,7 +186,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="BEf-3f-TPh" userLabel="Label Password Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -184,10 +194,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF" userLabel="ButtonConnectStackView">
-                                                        <rect key="frame" x="0.0" y="246" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="246" width="633" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="633" height="25"/>
                                                                 <state key="normal" title="Connect"/>
                                                                 <connections>
                                                                     <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
@@ -196,10 +206,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1" userLabel="ButtonHelpStackView">
-                                                        <rect key="frame" x="0.0" y="287" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="287" width="633" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="633" height="25"/>
                                                                 <state key="normal" title="Button url help link"/>
                                                                 <connections>
                                                                     <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
@@ -274,24 +284,26 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="activityIndicatorURLFooter" destination="Gsa-2t-LAX" id="oka-F4-vPh"/>
                         <outlet property="basicAuthInfoStackView" destination="kY0-Md-FsP" id="6kU-lP-WEK"/>
                         <outlet property="buttonConnect" destination="qcz-FW-RTp" id="lkF-6G-Pnj"/>
                         <outlet property="buttonHelpLink" destination="lUz-8C-zKg" id="gnX-eE-ywn"/>
-                        <outlet property="buttonReconectionURL" destination="eSw-Lz-XIR" id="3Dt-bN-Rtt"/>
                         <outlet property="buttonReconnection" destination="HUS-Qc-A5N" id="c26-Ww-cpG"/>
+                        <outlet property="buttonReconnectionURL" destination="eSw-Lz-XIR" id="XFo-t9-0xZ"/>
                         <outlet property="connectButtonStackView" destination="VCQ-68-5UF" id="SSe-hf-90h"/>
                         <outlet property="helpButtonStackView" destination="g4K-Wc-Pa1" id="Vgl-P4-thx"/>
                         <outlet property="imageViewLeftPassword" destination="08w-Yb-JUy" id="6Gr-Bt-R4e"/>
                         <outlet property="imageViewLeftURL" destination="kbb-33-8tT" id="Gpd-tv-l9d"/>
                         <outlet property="imageViewLogo" destination="e8b-Rl-Mh0" id="6bs-to-s7J"/>
                         <outlet property="imageViewPasswordFooter" destination="BJX-bG-Oio" id="jMj-ZE-Mda"/>
-                        <outlet property="imageViewRightPassword" destination="HO3-T3-Mmy" id="9Cv-DN-oIY"/>
                         <outlet property="imageViewTopInfo" destination="ayY-vm-DIf" id="E1T-Qe-M8b"/>
+                        <outlet property="imageViewURLFooter" destination="XqP-Ib-XSt" id="aOW-1M-nP6"/>
                         <outlet property="imageViewUsername" destination="TgF-b1-q7W" id="k70-cZ-xoz"/>
                         <outlet property="labelPasswordFooter" destination="BEf-3f-TPh" id="BeU-AJ-PUg"/>
                         <outlet property="labelTopInfo" destination="MFx-C4-5pN" id="B4K-w2-Eih"/>
                         <outlet property="labelURLFooter" destination="0NZ-MO-sTX" id="jj0-f6-6xb"/>
                         <outlet property="passwordStackView" destination="2BO-Lb-oZ2" id="0iH-UQ-thG"/>
+                        <outlet property="revealPasswordButton" destination="BR8-xb-EG9" id="jbv-at-Ivb"/>
                         <outlet property="scrollView" destination="6mr-Qy-Np8" id="Mc3-1A-fsR"/>
                         <outlet property="textFieldPassword" destination="3io-Sx-qiv" id="Kf4-lG-kZ3"/>
                         <outlet property="textFieldURL" destination="K3Y-mX-EWx" id="evx-Ry-FVD"/>
@@ -316,16 +328,16 @@
                         <viewControllerLayoutGuide type="bottom" id="XkD-Kd-VX0"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="T26-kj-Ka7">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
-                                <rect key="frame" x="0.0" y="44" width="320" height="724"/>
+                                <rect key="frame" x="0.0" y="44" width="768" height="980"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-q5-DCr">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem id="Srt-MH-Z13">
@@ -355,7 +367,6 @@
     <resources>
         <image name="CompanyLogo.png" width="300" height="200"/>
         <image name="ReconnectIcon.png" width="25" height="25"/>
-        <image name="RevealPasswordIcon.png" width="25" height="25"/>
         <image name="password.png" width="25" height="25"/>
         <image name="server.png" width="25" height="25"/>
         <image name="user.png" width="25" height="25"/>

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -62,14 +62,14 @@
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
-                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
+                                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
                                                                 <rect key="frame" x="727" y="0.0" width="25" height="25"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="width" constant="25" id="zag-UY-pi0"/>
+                                                                    <constraint firstAttribute="width" constant="25" id="uI9-CC-Mzh"/>
                                                                 </constraints>
                                                                 <state key="normal" title="Button" image="ReconnectIcon.png"/>
                                                                 <connections>
-                                                                    <action selector="reconnectionButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="71L-sL-XqG"/>
+                                                                    <action selector="reconnectionButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="JwI-o5-N9T"/>
                                                                 </connections>
                                                             </button>
                                                         </subviews>
@@ -85,11 +85,21 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="719" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="686" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
+                                                            <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
+                                                                <rect key="frame" x="727" y="0.0" width="25" height="25"/>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="width" constant="25" id="zag-UY-pi0"/>
+                                                                </constraints>
+                                                                <state key="normal" title="Button" image="ReconnectIcon.png"/>
+                                                                <connections>
+                                                                    <action selector="reconnectionButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="71L-sL-XqG"/>
+                                                                </connections>
+                                                            </button>
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G" userLabel="UsernameStackView">

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -11,7 +11,7 @@
         <!--Universal Login View Controller-->
         <scene sceneID="kL2-BC-pwF">
             <objects>
-                <viewController storyboardIdentifier="universalLoginViewController" useStoryboardIdentifierAsRestorationIdentifier="YES" id="iPx-pb-eEh" userLabel="Universal Login View Controller" customClass="UniversalLoginViewController" customModule="Owncloud_iOs_Client" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="universalLoginViewController" automaticallyAdjustsScrollViewInsets="NO" useStoryboardIdentifierAsRestorationIdentifier="YES" id="iPx-pb-eEh" userLabel="Universal Login View Controller" customClass="UniversalLoginViewController" customModule="Owncloud_iOs_Client" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="Wlp-fe-Gsf"/>
                         <viewControllerLayoutGuide type="bottom" id="Nrw-Uw-7nS"/>
@@ -21,7 +21,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
-                                <rect key="frame" x="0.0" y="20" width="375" height="647"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="452"/>
@@ -76,12 +76,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" tag="1" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="310" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="277" height="25"/>
                                                                 <nil key="textColor"/>
+                                                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="343" y="0.0" width="0.0" height="25"/>
+                                                                <rect key="frame" x="318" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="d2d-vw-fSp"/>
                                                                     <constraint firstAttribute="width" constant="25" id="uI9-CC-Mzh"/>
@@ -124,13 +125,13 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="310" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="277" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="343" y="0.0" width="0.0" height="25"/>
+                                                                <rect key="frame" x="318" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="g7S-dq-MGB"/>
                                                                     <constraint firstAttribute="width" constant="25" id="qNr-gK-AbW"/>
@@ -171,7 +172,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" tag="3" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="310" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="277" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
@@ -180,7 +181,7 @@
                                                                 </connections>
                                                             </textField>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BR8-xb-EG9">
-                                                                <rect key="frame" x="343" y="0.0" width="0.0" height="25"/>
+                                                                <rect key="frame" x="318" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="25" id="ccj-FV-NUm"/>
                                                                     <constraint firstAttribute="height" constant="25" id="ojW-d0-sXL"/>
@@ -294,11 +295,12 @@
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="6mr-Qy-Np8" secondAttribute="trailing" id="284-pb-CAm"/>
-                            <constraint firstItem="6mr-Qy-Np8" firstAttribute="top" secondItem="Wlp-fe-Gsf" secondAttribute="bottom" id="Khe-DA-eVr"/>
+                            <constraint firstItem="6mr-Qy-Np8" firstAttribute="top" secondItem="Wlp-fe-Gsf" secondAttribute="bottom" constant="-20" id="Khe-DA-eVr"/>
                             <constraint firstItem="Nrw-Uw-7nS" firstAttribute="top" secondItem="6mr-Qy-Np8" secondAttribute="bottom" id="lkv-6h-rV1"/>
                             <constraint firstItem="6mr-Qy-Np8" firstAttribute="leading" secondItem="dxR-Vh-mRQ" secondAttribute="leading" id="vIh-rd-nk7"/>
                         </constraints>
                     </view>
+                    <extendedEdge key="edgesForExtendedLayout" bottom="YES"/>
                     <connections>
                         <outlet property="activityIndicatorURLFooter" destination="Gsa-2t-LAX" id="oka-F4-vPh"/>
                         <outlet property="basicAuthInfoStackView" destination="kY0-Md-FsP" id="6kU-lP-WEK"/>
@@ -333,7 +335,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1kC-5M-QFu" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-51.358695652173914" y="-10.144927536231885"/>
+            <point key="canvasLocation" x="-52" y="-10.344827586206897"/>
         </scene>
         <!--Web Login View Controller-->
         <scene sceneID="aXj-g5-zsT">

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -99,7 +99,6 @@
                                                                         </constraints>
                                                                     </imageView>
                                                                 </subviews>
-                                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                                 <constraints>
                                                                     <constraint firstItem="Gsa-2t-LAX" firstAttribute="top" secondItem="gJX-YZ-wjT" secondAttribute="top" constant="2" id="AIY-QL-9Mw"/>
                                                                     <constraint firstAttribute="width" constant="25" id="BfV-EZ-IzJ"/>

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -56,7 +56,7 @@
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
                                                             </imageView>
-                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
                                                                 <rect key="frame" x="33" y="0.0" width="686" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -112,7 +112,7 @@
                                                                     <constraint firstAttribute="height" constant="25" id="ceD-ec-4ry"/>
                                                                 </constraints>
                                                             </imageView>
-                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="username" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
                                                                 <rect key="frame" x="33" y="0.0" width="719" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -130,13 +130,13 @@
                                                                     <constraint firstAttribute="height" constant="25" id="tBm-nZ-Wff"/>
                                                                 </constraints>
                                                             </imageView>
-                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
+                                                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
                                                                 <rect key="frame" x="33" y="0.0" width="686" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits"/>
+                                                                <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                                             </textField>
-                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
+                                                            <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
                                                                 <rect key="frame" x="727" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="Mix-F4-13T"/>

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="ipad9_7" orientation="landscape">
-        <adaptation id="splitview1_3"/>
+    <device id="retina5_5" orientation="landscape">
+        <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
@@ -17,23 +17,23 @@
                         <viewControllerLayoutGuide type="bottom" id="Nrw-Uw-7nS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dxR-Vh-mRQ">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
-                                <rect key="frame" x="7" y="20" width="313" height="748"/>
+                                <rect key="frame" x="7" y="20" width="729" height="394"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
-                                        <rect key="frame" x="0.0" y="0.0" width="313" height="512"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="729" height="512"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
-                                                <rect key="frame" x="0.0" y="0.0" width="313" height="200"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="729" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="yIK-Tu-q6d" userLabel="LoginStackView">
-                                                <rect key="frame" x="16" y="200" width="281" height="312"/>
+                                                <rect key="frame" x="32" y="200" width="665" height="312"/>
                                                 <subviews>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC" userLabel="TopInfoStackView">
-                                                        <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="665" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ayY-vm-DIf" userLabel="Image Top Info">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -43,7 +43,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="MFx-C4-5pN" userLabel="Label Top Info">
-                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="632" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -51,19 +51,19 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2" userLabel="URLStackView">
-                                                        <rect key="frame" x="0.0" y="41" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="41" width="665" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="599" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="640" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="25" id="uI9-CC-Mzh"/>
                                                                 </constraints>
@@ -74,27 +74,47 @@
                                                             </button>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf" userLabel="URLInfoStackView">
-                                                        <rect key="frame" x="0.0" y="82" width="281" height="25"/>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf" userLabel="URLInfoStackView">
+                                                        <rect key="frame" x="0.0" y="82" width="665" height="25"/>
                                                         <subviews>
-                                                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="w1a-U9-TaZ" userLabel="Image View URL Footer">
+                                                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="gJX-YZ-wjT">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                                <subviews>
+                                                                    <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="Gsa-2t-LAX">
+                                                                        <rect key="frame" x="2" y="2" width="20" height="20"/>
+                                                                    </activityIndicatorView>
+                                                                    <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="XqP-Ib-XSt">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="25" id="SIr-gS-2ph"/>
+                                                                            <constraint firstAttribute="width" constant="25" id="bj0-Db-Dtb"/>
+                                                                        </constraints>
+                                                                    </imageView>
+                                                                </subviews>
+                                                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="height" constant="25" id="nZN-1F-UJd"/>
-                                                                    <constraint firstAttribute="width" constant="25" id="vSb-FK-Xp3"/>
+                                                                    <constraint firstItem="Gsa-2t-LAX" firstAttribute="top" secondItem="gJX-YZ-wjT" secondAttribute="top" constant="2" id="AIY-QL-9Mw"/>
+                                                                    <constraint firstAttribute="width" constant="25" id="BfV-EZ-IzJ"/>
+                                                                    <constraint firstAttribute="bottom" secondItem="Gsa-2t-LAX" secondAttribute="bottom" constant="3" id="Bjm-7T-tOC"/>
+                                                                    <constraint firstItem="XqP-Ib-XSt" firstAttribute="leading" secondItem="gJX-YZ-wjT" secondAttribute="leading" id="FUK-9i-Rhf"/>
+                                                                    <constraint firstItem="Gsa-2t-LAX" firstAttribute="leading" secondItem="gJX-YZ-wjT" secondAttribute="leading" constant="2" id="Xwz-6a-SOS"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="XqP-Ib-XSt" secondAttribute="trailing" id="aKf-pl-9as"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="Gsa-2t-LAX" secondAttribute="trailing" constant="3" id="dup-4t-mBX"/>
+                                                                    <constraint firstAttribute="bottom" secondItem="XqP-Ib-XSt" secondAttribute="bottom" id="vy8-VL-JiJ"/>
+                                                                    <constraint firstItem="XqP-Ib-XSt" firstAttribute="top" secondItem="gJX-YZ-wjT" secondAttribute="top" id="zs5-3p-Fww"/>
                                                                 </constraints>
-                                                            </imageView>
-                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
+                                                            </view>
+                                                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
+                                                                <rect key="frame" x="33" y="0.0" width="599" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="640" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="g7S-dq-MGB"/>
-                                                                    <constraint firstAttribute="width" constant="25" id="hD6-Ut-R80"/>
+                                                                    <constraint firstAttribute="width" constant="25" id="qNr-gK-AbW"/>
                                                                 </constraints>
                                                                 <state key="normal" title="Button" image="ReconnectIcon.png"/>
                                                                 <connections>
@@ -104,7 +124,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G" userLabel="UsernameStackView">
-                                                        <rect key="frame" x="0.0" y="123" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="123" width="665" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -114,7 +134,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="username" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
-                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="632" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
@@ -122,7 +142,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2" userLabel="PasswordStackView">
-                                                        <rect key="frame" x="0.0" y="164" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="164" width="665" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -132,13 +152,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="215" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="599" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                                             </textField>
                                                             <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
-                                                                <rect key="frame" x="256" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="640" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="Mix-F4-13T"/>
                                                                 </constraints>
@@ -146,7 +166,7 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kY0-Md-FsP" userLabel="BasicAuthInfoStackVIew">
-                                                        <rect key="frame" x="0.0" y="205" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="205" width="665" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BJX-bG-Oio" userLabel="Image View Password Footer">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -156,7 +176,7 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="BEf-3f-TPh" userLabel="Label Password Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="248" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="632" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
@@ -164,10 +184,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF" userLabel="ButtonConnectStackView">
-                                                        <rect key="frame" x="0.0" y="246" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="246" width="665" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="665" height="25"/>
                                                                 <state key="normal" title="Connect"/>
                                                                 <connections>
                                                                     <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
@@ -176,10 +196,10 @@
                                                         </subviews>
                                                     </stackView>
                                                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1" userLabel="ButtonHelpStackView">
-                                                        <rect key="frame" x="0.0" y="287" width="281" height="25"/>
+                                                        <rect key="frame" x="0.0" y="287" width="665" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="281" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="665" height="25"/>
                                                                 <state key="normal" title="Button url help link"/>
                                                                 <connections>
                                                                     <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
@@ -216,6 +236,11 @@
                                             <mask key="constraints">
                                                 <include reference="as0-kh-7bM"/>
                                                 <exclude reference="gYI-an-fUb"/>
+                                            </mask>
+                                        </variation>
+                                        <variation key="heightClass=compact-widthClass=regular">
+                                            <mask key="constraints">
+                                                <include reference="gYI-an-fUb"/>
                                             </mask>
                                         </variation>
                                         <variation key="heightClass=regular-widthClass=compact">
@@ -262,7 +287,6 @@
                         <outlet property="imageViewPasswordFooter" destination="BJX-bG-Oio" id="jMj-ZE-Mda"/>
                         <outlet property="imageViewRightPassword" destination="HO3-T3-Mmy" id="9Cv-DN-oIY"/>
                         <outlet property="imageViewTopInfo" destination="ayY-vm-DIf" id="E1T-Qe-M8b"/>
-                        <outlet property="imageViewURLFooter" destination="w1a-U9-TaZ" id="G2d-FG-Lo1"/>
                         <outlet property="imageViewUsername" destination="TgF-b1-q7W" id="k70-cZ-xoz"/>
                         <outlet property="labelPasswordFooter" destination="BEf-3f-TPh" id="BeU-AJ-PUg"/>
                         <outlet property="labelTopInfo" destination="MFx-C4-5pN" id="B4K-w2-Eih"/>
@@ -281,7 +305,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1kC-5M-QFu" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="-50.9765625" y="-9.2240117130307464"/>
+            <point key="canvasLocation" x="-51.358695652173914" y="-10.144927536231885"/>
         </scene>
         <!--Web Login View Controller-->
         <scene sceneID="aXj-g5-zsT">
@@ -292,16 +316,16 @@
                         <viewControllerLayoutGuide type="bottom" id="XkD-Kd-VX0"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="T26-kj-Ka7">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="768"/>
+                        <rect key="frame" x="0.0" y="0.0" width="736" height="414"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
-                                <rect key="frame" x="0.0" y="44" width="320" height="724"/>
+                                <rect key="frame" x="0.0" y="44" width="736" height="370"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-q5-DCr">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="736" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem id="Srt-MH-Z13">

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -61,13 +61,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="url" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="567" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button hidden="YES" opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eSw-Lz-XIR" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="608" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="633" y="0.0" width="0.0" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="d2d-vw-fSp"/>
                                                                     <constraint firstAttribute="width" constant="25" id="uI9-CC-Mzh"/>
@@ -111,13 +111,13 @@
                                                                 </constraints>
                                                             </view>
                                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" text="" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" minimumFontSize="7" translatesAutoresizingMaskIntoConstraints="NO" id="0NZ-MO-sTX" userLabel="Label URL Footer">
-                                                                <rect key="frame" x="33" y="0.0" width="567" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="13"/>
                                                                 <nil key="textColor"/>
                                                                 <nil key="highlightedColor"/>
                                                             </label>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="1000" horizontalCompressionResistancePriority="1000" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="608" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="633" y="0.0" width="0.0" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="g7S-dq-MGB"/>
                                                                     <constraint firstAttribute="width" constant="25" id="qNr-gK-AbW"/>
@@ -158,13 +158,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" restorationIdentifier="password" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="567" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="600" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                                             </textField>
                                                             <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BR8-xb-EG9">
-                                                                <rect key="frame" x="608" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="633" y="0.0" width="0.0" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="25" id="ccj-FV-NUm"/>
                                                                     <constraint firstAttribute="height" constant="25" id="ojW-d0-sXL"/>
@@ -312,7 +312,7 @@
                         <outlet property="urlInfoStackView" destination="cOi-fS-vwf" id="JYO-mt-fcA"/>
                         <outlet property="urlStackView" destination="EnR-aJ-yK2" id="9NE-n3-QCd"/>
                         <outlet property="usernameStackView" destination="wsI-KP-W6G" id="d7c-AU-H12"/>
-                        <segue destination="f4N-GJ-PQD" kind="presentation" identifier="segueToWebLoginView" id="S2O-4z-eW2"/>
+                        <segue destination="T7Q-cG-tn1" kind="presentation" identifier="segueToWebLoginView" id="S2O-4z-eW2"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="1kC-5M-QFu" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -331,29 +331,21 @@
                         <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <webView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
-                                <rect key="frame" x="0.0" y="44" width="768" height="980"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <webView contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
+                                <rect key="frame" x="0.0" y="0.0" width="768" height="1024"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
-                            <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-q5-DCr">
-                                <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
-                                <items>
-                                    <navigationItem id="Srt-MH-Z13">
-                                        <barButtonItem key="rightBarButtonItem" title="Item" id="Yhs-Ln-8f5" userLabel="Item cancel">
-                                            <connections>
-                                                <action selector="cancelButtonTapped:" destination="f4N-GJ-PQD" id="j7m-7k-00M"/>
-                                            </connections>
-                                        </barButtonItem>
-                                    </navigationItem>
-                                </items>
-                            </navigationBar>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstAttribute="trailing" secondItem="qbt-Jk-Nkc" secondAttribute="trailing" id="5kw-ES-bv6"/>
+                            <constraint firstItem="qbt-Jk-Nkc" firstAttribute="leading" secondItem="T26-kj-Ka7" secondAttribute="leading" id="pdl-g3-pXM"/>
+                            <constraint firstItem="qbt-Jk-Nkc" firstAttribute="top" secondItem="T26-kj-Ka7" secondAttribute="top" id="tQW-2b-WlN"/>
+                            <constraint firstItem="XkD-Kd-VX0" firstAttribute="top" secondItem="qbt-Jk-Nkc" secondAttribute="bottom" id="tWH-TO-pPd"/>
+                        </constraints>
                     </view>
+                    <navigationItem key="navigationItem" id="Ixp-d8-gr3"/>
                     <connections>
-                        <outlet property="cancelButton" destination="Yhs-Ln-8f5" id="q4U-Xr-vI2"/>
                         <outlet property="webViewLogin" destination="qbt-Jk-Nkc" id="6yt-1o-xB0"/>
                         <segue destination="gOD-iC-eEd" kind="unwind" identifier="unwindToMainLoginView" unwindAction="unwindToMainLoginViewWithSegue:" id="hoy-NS-fHW"/>
                     </connections>
@@ -361,7 +353,25 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iLP-HP-ZaL" userLabel="First Responder" sceneMemberID="firstResponder"/>
                 <exit id="gOD-iC-eEd" userLabel="Exit" sceneMemberID="exit"/>
             </objects>
-            <point key="canvasLocation" x="891" y="-121"/>
+            <point key="canvasLocation" x="1656.25" y="-121.28906249999999"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="0uD-kd-dlo">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="T7Q-cG-tn1" customClass="OCNavigationController" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="o9e-Ar-I5G">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="f4N-GJ-PQD" kind="relationship" relationship="rootViewController" id="Gvm-OY-uw7"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Rc3-lz-mQM" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="890.625" y="-121.28906249999999"/>
         </scene>
     </scenes>
     <resources>

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16A323" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
-    <device id="ipad12_9" orientation="portrait">
+    <device id="retina4_0" orientation="landscape">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
@@ -17,22 +17,22 @@
                         <viewControllerLayoutGuide type="bottom" id="Nrw-Uw-7nS"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="dxR-Vh-mRQ">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
+                            <scrollView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" ambiguous="YES" preservesSuperviewLayoutMargins="YES" bounces="NO" alwaysBounceVertical="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6mr-Qy-Np8">
                                 <rect key="frame" x="8" y="20" width="552" height="300"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" translatesAutoresizingMaskIntoConstraints="NO" id="UTQ-pq-jrl" userLabel="GolbalStackView">
-                                        <rect key="frame" x="0.0" y="0.0" width="1008" height="512"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="552" height="512"/>
                                         <subviews>
                                             <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="CompanyLogo.png" translatesAutoresizingMaskIntoConstraints="NO" id="e8b-Rl-Mh0" userLabel="Image View Logo">
-                                                <rect key="frame" x="0.0" y="0.0" width="1008" height="200"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="552" height="200"/>
                                             </imageView>
                                             <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" alignment="top" spacing="16" translatesAutoresizingMaskIntoConstraints="NO" id="yIK-Tu-q6d" userLabel="LoginStackView">
-                                                <rect key="frame" x="0.0" y="200" width="1008" height="312"/>
+                                                <rect key="frame" x="0.0" y="200" width="552" height="312"/>
                                                 <subviews>
-                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC">
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="HZa-qF-5hC" userLabel="TopInfoStackView">
                                                         <rect key="frame" x="0.0" y="0.0" width="58" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="ayY-vm-DIf" userLabel="Image Top Info">
@@ -50,20 +50,20 @@
                                                             </label>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2">
-                                                        <rect key="frame" x="0.0" y="41" width="1008" height="25"/>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="EnR-aJ-yK2" userLabel="URLStackView">
+                                                        <rect key="frame" x="0.0" y="41" width="552" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="server.png" translatesAutoresizingMaskIntoConstraints="NO" id="kbb-33-8tT" userLabel="Image View Left URL">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="K3Y-mX-EWx" userLabel="Text Field URL">
-                                                                <rect key="frame" x="33" y="0.0" width="942" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="486" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="HUS-Qc-A5N" userLabel="Button Reconnection">
-                                                                <rect key="frame" x="983" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="527" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="width" constant="25" id="zag-UY-pi0"/>
                                                                 </constraints>
@@ -74,7 +74,7 @@
                                                             </button>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf">
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="cOi-fS-vwf" userLabel="URLInfoStackView">
                                                         <rect key="frame" x="0.0" y="82" width="58" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="w1a-U9-TaZ" userLabel="Image View URL Footer">
@@ -92,8 +92,8 @@
                                                             </label>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G">
-                                                        <rect key="frame" x="0.0" y="123" width="1008" height="25"/>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="wsI-KP-W6G" userLabel="UsernameStackView">
+                                                        <rect key="frame" x="0.0" y="123" width="552" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="user.png" translatesAutoresizingMaskIntoConstraints="NO" id="TgF-b1-q7W" userLabel="Image View Username">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -103,15 +103,15 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="holita" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="L65-Zl-2qP" userLabel="Text Field Username">
-                                                                <rect key="frame" x="33" y="0.0" width="975" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="519" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2">
-                                                        <rect key="frame" x="0.0" y="164" width="1008" height="25"/>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="2BO-Lb-oZ2" userLabel="PasswordStackView">
+                                                        <rect key="frame" x="0.0" y="164" width="552" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="password.png" translatesAutoresizingMaskIntoConstraints="NO" id="08w-Yb-JUy" userLabel="Image View Left Password">
                                                                 <rect key="frame" x="0.0" y="0.0" width="25" height="25"/>
@@ -121,13 +121,13 @@
                                                                 </constraints>
                                                             </imageView>
                                                             <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" text="password" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="3io-Sx-qiv" userLabel="Text Field Password">
-                                                                <rect key="frame" x="33" y="0.0" width="942" height="25"/>
+                                                                <rect key="frame" x="33" y="0.0" width="486" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                                 <textInputTraits key="textInputTraits"/>
                                                             </textField>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="RevealPasswordIcon.png" translatesAutoresizingMaskIntoConstraints="NO" id="HO3-T3-Mmy">
-                                                                <rect key="frame" x="983" y="0.0" width="25" height="25"/>
+                                                                <rect key="frame" x="527" y="0.0" width="25" height="25"/>
                                                                 <constraints>
                                                                     <constraint firstAttribute="height" constant="25" id="Mix-F4-13T"/>
                                                                     <constraint firstAttribute="width" constant="25" id="tGK-e9-qDL"/>
@@ -135,7 +135,7 @@
                                                             </imageView>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kY0-Md-FsP">
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="kY0-Md-FsP" userLabel="BasicAuthInfoStackVIew">
                                                         <rect key="frame" x="0.0" y="205" width="58" height="25"/>
                                                         <subviews>
                                                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="BJX-bG-Oio" userLabel="Image View Password Footer">
@@ -153,11 +153,11 @@
                                                             </label>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF">
-                                                        <rect key="frame" x="0.0" y="246" width="1008" height="25"/>
+                                                    <stackView opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="VCQ-68-5UF" userLabel="ButtonConnectStackView">
+                                                        <rect key="frame" x="0.0" y="246" width="552" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="qcz-FW-RTp">
-                                                                <rect key="frame" x="0.0" y="0.0" width="1008" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="552" height="25"/>
                                                                 <state key="normal" title="Connect"/>
                                                                 <connections>
                                                                     <action selector="connectButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="yRg-q5-hDU"/>
@@ -165,11 +165,11 @@
                                                             </button>
                                                         </subviews>
                                                     </stackView>
-                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1">
-                                                        <rect key="frame" x="0.0" y="287" width="1008" height="25"/>
+                                                    <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="g4K-Wc-Pa1" userLabel="ButtonHelpStackView">
+                                                        <rect key="frame" x="0.0" y="287" width="552" height="25"/>
                                                         <subviews>
                                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lUz-8C-zKg">
-                                                                <rect key="frame" x="0.0" y="0.0" width="1008" height="25"/>
+                                                                <rect key="frame" x="0.0" y="0.0" width="552" height="25"/>
                                                                 <state key="normal" title="Button url help link"/>
                                                                 <connections>
                                                                     <action selector="helpLinkButtonTapped:" destination="iPx-pb-eEh" eventType="touchUpInside" id="ZZ2-Ih-oNe"/>
@@ -210,9 +210,12 @@
                         </constraints>
                     </view>
                     <connections>
+                        <outlet property="basicAuthInfoStackView" destination="kY0-Md-FsP" id="6kU-lP-WEK"/>
                         <outlet property="buttonConnect" destination="qcz-FW-RTp" id="lkF-6G-Pnj"/>
                         <outlet property="buttonHelpLink" destination="lUz-8C-zKg" id="gnX-eE-ywn"/>
                         <outlet property="buttonReconnection" destination="HUS-Qc-A5N" id="c26-Ww-cpG"/>
+                        <outlet property="connectButtonStackView" destination="VCQ-68-5UF" id="SSe-hf-90h"/>
+                        <outlet property="helpButtonStackView" destination="g4K-Wc-Pa1" id="Vgl-P4-thx"/>
                         <outlet property="imageViewLeftPassword" destination="08w-Yb-JUy" id="6Gr-Bt-R4e"/>
                         <outlet property="imageViewLeftURL" destination="kbb-33-8tT" id="Gpd-tv-l9d"/>
                         <outlet property="imageViewLogo" destination="e8b-Rl-Mh0" id="6bs-to-s7J"/>
@@ -224,9 +227,14 @@
                         <outlet property="labelPasswordFooter" destination="cMk-he-xem" id="Cnj-j4-7Rl"/>
                         <outlet property="labelTopInfo" destination="UMG-rI-qTw" id="TRB-Ct-Jtf"/>
                         <outlet property="labelURLFooter" destination="ng2-Du-gwx" id="p1k-YG-5WB"/>
+                        <outlet property="passwordStackView" destination="2BO-Lb-oZ2" id="0iH-UQ-thG"/>
                         <outlet property="textFieldPassword" destination="3io-Sx-qiv" id="Kf4-lG-kZ3"/>
                         <outlet property="textFieldURL" destination="K3Y-mX-EWx" id="evx-Ry-FVD"/>
                         <outlet property="textFieldUsername" destination="L65-Zl-2qP" id="gQL-J4-iaP"/>
+                        <outlet property="topInfoStackView" destination="HZa-qF-5hC" id="bRd-Pu-Xrm"/>
+                        <outlet property="urlInfoStackView" destination="cOi-fS-vwf" id="JYO-mt-fcA"/>
+                        <outlet property="urlStackView" destination="EnR-aJ-yK2" id="9NE-n3-QCd"/>
+                        <outlet property="usernameStackView" destination="wsI-KP-W6G" id="d7c-AU-H12"/>
                         <segue destination="f4N-GJ-PQD" kind="presentation" identifier="segueToWebLoginView" id="S2O-4z-eW2"/>
                     </connections>
                 </viewController>
@@ -243,7 +251,7 @@
                         <viewControllerLayoutGuide type="bottom" id="8vk-wX-RyQ"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="4sS-h1-K1u">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sRS-t9-TB6" userLabel="Image View Logo">
@@ -330,16 +338,16 @@
                         <viewControllerLayoutGuide type="bottom" id="XkD-Kd-VX0"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="T26-kj-Ka7">
-                        <rect key="frame" x="0.0" y="0.0" width="1024" height="1366"/>
+                        <rect key="frame" x="0.0" y="0.0" width="568" height="320"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <webView contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qbt-Jk-Nkc">
-                                <rect key="frame" x="0.0" y="44" width="1024" height="1322"/>
+                                <rect key="frame" x="0.0" y="44" width="568" height="276"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <color key="backgroundColor" red="0.36078431370000003" green="0.38823529410000002" blue="0.4039215686" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                             <navigationBar contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HV6-q5-DCr">
-                                <rect key="frame" x="0.0" y="0.0" width="1024" height="44"/>
+                                <rect key="frame" x="0.0" y="0.0" width="568" height="44"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem id="Srt-MH-Z13">

--- a/Owncloud iOs Client/Main.storyboard
+++ b/Owncloud iOs Client/Main.storyboard
@@ -143,7 +143,7 @@
                                                                 <rect key="frame" x="33" y="0.0" width="600" height="25"/>
                                                                 <nil key="textColor"/>
                                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                                <textInputTraits key="textInputTraits"/>
+                                                                <textInputTraits key="textInputTraits" returnKeyType="next"/>
                                                             </textField>
                                                         </subviews>
                                                     </stackView>
@@ -341,7 +341,7 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                                 <items>
                                     <navigationItem id="Srt-MH-Z13">
-                                        <barButtonItem key="leftBarButtonItem" title="Item" id="Yhs-Ln-8f5" userLabel="Item cancel">
+                                        <barButtonItem key="rightBarButtonItem" title="Item" id="Yhs-Ln-8f5" userLabel="Item cancel">
                                             <connections>
                                                 <action selector="cancelButtonTapped:" destination="f4N-GJ-PQD" id="j7m-7k-00M"/>
                                             </connections>


### PR DESCRIPTION
New design for the login view. 
The new design is compatible with Iphone and Ipad and all the size classes.

- [X]  Handle open help link url @pablocarmu
- [X] UI/UX improvements
- - [x] Handle keyboards @pablocarmu
- - [x] Set branded style in view:
- - - [x] Navigation bar @pablocarmu
- - - [x] Background @pablocarmu
- - - [x] Login button.  @pablocarmu
- - - [X]  Text color of status bar [WIP] @pablocarmu 
- -  [X] Set custom title of button help link @pablocarmu 
- - [x] use and update constraits to url user password changes (stacks views, fixed height) @pablocarmu
- - [x] show/hide eye button to show password without encryption  @pablocarmu
- - [x] Show network Activity https://github.com/owncloud/ios/issues/872 @pablocarmu
- - [X] others suggestions https://github.com/owncloud/ios/issues/877  @pablocarmu