### PR TITLE
Reflect forbidden reshare

### DIFF
--- a/Owncloud iOs Client.xcodeproj/project.pbxproj
+++ b/Owncloud iOs Client.xcodeproj/project.pbxproj
@@ -380,6 +380,7 @@
 		40CF2C6F1C491D200047969A /* ShareUserPrivilegeCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40CF2C6E1C491D200047969A /* ShareUserPrivilegeCell.swift */; };
 		40D090841F97BA6A0030B9F9 /* DetectUserData.m in Sources */ = {isa = PBXBuildFile; fileRef = 40D090831F97BA6A0030B9F9 /* DetectUserData.m */; };
 		40D3F18E1EFD53E7004F0E22 /* WebLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D3F18D1EFD53E7004F0E22 /* WebLoginViewController.swift */; };
+		40D740F31F94B07D0009F0CC /* DetectUserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40D740F21F94B07D0009F0CC /* DetectUserData.swift */; };
 		40DC9C671CDA191B00F5F5EF /* EditFileViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 40DC9C651CDA191B00F5F5EF /* EditFileViewController.m */; };
 		40DC9C681CDA191B00F5F5EF /* EditFileViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 40DC9C661CDA191B00F5F5EF /* EditFileViewController.xib */; };
 		40DD9AE01D228E0C008E99D6 /* UtilsNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = 40DD9ADF1D228E0C008E99D6 /* UtilsNotifications.m */; };
@@ -1551,6 +1552,7 @@
 		40D090821F97BA6A0030B9F9 /* DetectUserData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DetectUserData.h; sourceTree = "<group>"; };
 		40D090831F97BA6A0030B9F9 /* DetectUserData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = DetectUserData.m; sourceTree = "<group>"; };
 		40D3F18D1EFD53E7004F0E22 /* WebLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebLoginViewController.swift; sourceTree = "<group>"; };
+		40D740F21F94B07D0009F0CC /* DetectUserData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetectUserData.swift; sourceTree = "<group>"; };
 		40DC9C641CDA191B00F5F5EF /* EditFileViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = EditFileViewController.h; sourceTree = "<group>"; };
 		40DC9C651CDA191B00F5F5EF /* EditFileViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = EditFileViewController.m; sourceTree = "<group>"; };
 		40DC9C661CDA191B00F5F5EF /* EditFileViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = EditFileViewController.xib; sourceTree = "<group>"; };
@@ -4724,6 +4726,7 @@
 				EAF771311B73523800ED6E6E /* SystemConstants-swift.swift in Sources */,
 				59BF9B361A2C8BEA009D9CF0 /* DocumentPickerViewController.m in Sources */,
 				59BF9B371A2C8BEA009D9CF0 /* FileListDocumentProviderViewController.m in Sources */,
+				40D740F31F94B07D0009F0CC /* DetectUserData.swift in Sources */,
 				1324298915ADBB3700DF823E /* main.m in Sources */,
 				EA4070FE1C11B82B008B1507 /* UIImage+Thumbnail.m in Sources */,
 				40D3F18E1EFD53E7004F0E22 /* WebLoginViewController.swift in Sources */,

--- a/Owncloud iOs Client/AppDelegate.m
+++ b/Owncloud iOs Client/AppDelegate.m
@@ -186,7 +186,7 @@ float shortDelay = 0.3;
         
         ManageAccounts *manageAccounts = [ManageAccounts new];
         [manageAccounts updateDisplayNameOfUserWithUser:self.activeUser];
-        
+
         //if we are migrating url not relaunch sync
         if (![UtilsUrls isNecessaryUpdateToPredefinedUrlByPreviousUrl:self.activeUser.predefinedUrl]) {
             //Update favorites files if there are active user

--- a/Owncloud iOs Client/Files/Preview/DetailView/DetailViewController.m
+++ b/Owncloud iOs Client/Files/Preview/DetailView/DetailViewController.m
@@ -186,7 +186,9 @@
         _titleLabelMarginRightConstraint.constant = 210;
         _updatingProgressMarginUpdatingRightConstraint.constant = 210;
         
-        if ((k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
+        //Check if share link button should be appear.
+        if ([ShareUtils hasShareOptionToBeHiddenForFile:self.file]) {
+            
             [items insertObject:_deleteButtonBar atIndex:indexPosition++];
             
             if ([FileNameUtils isEditTextViewSupportedThisFile:self.file.fileName]) {

--- a/Owncloud iOs Client/Files/Preview/FilePreview/FilePreviewViewController.m
+++ b/Owncloud iOs Client/Files/Preview/FilePreview/FilePreviewViewController.m
@@ -145,7 +145,7 @@ NSString * iPhoneShowNotConnectionWithServerMessageNotification = @"iPhoneShowNo
     }
     
     //Check if share link button should be appear.
-    if ((k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
+    if ([ShareUtils hasShareOptionToBeHiddenForFile:self.file]) {
         NSMutableArray *customItems = [NSMutableArray arrayWithArray:self.toolBar.items];
         [customItems removeObjectIdenticalTo:_shareButtonBar];
         [customItems removeObjectIdenticalTo:_flexibleSpaceAfterShareButtonBar];

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -833,6 +833,7 @@ public enum TextfieldType: String {
     
     func detectUserDataAndValidate(credentials: OCCredentialsDto, serverPath: String) {
         
+
         DetectUserData .getUserDisplayName(ofServer: serverPath, credentials: credentials) { (displayName, error) in
             
              if (displayName != nil) {
@@ -848,7 +849,9 @@ public enum TextfieldType: String {
             self.validateCredentialsAndStoreAccount(credentials: credentials)
         }
         
+        
     }
+    
     
     
     func validateCredentialsAndStoreAccount(credentials: OCCredentialsDto) {

--- a/Owncloud iOs Client/Network/UserData/DetectUserData.swift
+++ b/Owncloud iOs Client/Network/UserData/DetectUserData.swift
@@ -1,0 +1,43 @@
+//
+//  DetectUserData.swift
+//  Owncloud iOs Client
+//
+//  Created by Noelia Alvarez on 16/10/2017.
+//
+//
+
+/*
+ Copyright (C) 2017, ownCloud GmbH.
+ This code is covered by the GNU Public License Version 3.
+ For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
+ You should have received a copy of this license
+ along with this program. If not, see <http://www.gnu.org/licenses/gpl-3.0.en.html>.
+ */
+
+import Foundation
+
+
+@objc class DetectUserData: NSObject {
+    
+    func getUserDisplayNameOfServer(path: String, credentials: OCCredentialsDto,
+                                    withCompletion completion:(@escaping (_ displayName: String?,_ errorHttp: NSInteger?,_ error: NSError?) -> Void ) ){
+        
+        AppDelegate.sharedOCCommunication().setCredentials(credentials)
+        AppDelegate.sharedOCCommunication().setValueOfUserAgent(UtilsUrls.getUserAgent())
+        
+        AppDelegate.sharedOCCommunication().getUserDisplayName(ofServer: path,
+                                                               on: AppDelegate.sharedOCCommunication(),
+                                                               success: { (response: HTTPURLResponse?, displayName: String?, redirectServer: String?) in
+                                                                
+                                                                completion(displayName, response?.statusCode, nil)
+                                                                
+        },failure: { (response: HTTPURLResponse?, error: Error?, redirectServer: String?) in
+            
+            let statusCode: NSInteger = (response?.statusCode == nil) ? 0: (response?.statusCode)!
+            
+            completion(nil, statusCode, error! as NSError)
+        })
+    }
+    
+    
+}

--- a/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
+++ b/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
@@ -1381,7 +1381,7 @@
         //Custom cell for SWTableViewCell with right swipe options
         fileCell.containingTableView = tableView;
         [fileCell setCellHeight:fileCell.frame.size.height];
-        fileCell.leftUtilityButtons = [self setSwipeLeftButtons];
+        fileCell.leftUtilityButtons = [self setSwipeLeftButtonsForFile:file];
         
         fileCell.rightUtilityButtons = nil;
         fileCell.delegate = self;
@@ -3384,13 +3384,13 @@
  *
  */
 
-- (NSArray *)setSwipeLeftButtons
+- (NSArray *)setSwipeLeftButtonsForFile:(FileDto *)file
 {
     //Share gray button
     NSMutableArray *rightUtilityButtons = [NSMutableArray new];
     
     BOOL areTwoButtonsInTheSwipe = false;
-    if ( (k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled) ) {
+    if ([ShareUtils hasShareOptionToBeHiddenForFile:file]) {
         //Two buttons
         areTwoButtonsInTheSwipe = true;
     }else{
@@ -3456,7 +3456,7 @@
         }
         case 1:
         {
-            if ((k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
+            if ([ShareUtils hasShareOptionToBeHiddenForFile:self.selectedFileDto]) {
                 DLog(@"Click on index 2 - Delete");
                 [self didSelectDeleteOption];
                 break;
@@ -3469,8 +3469,7 @@
         }
         case 2:
         {
-            if ((k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
-            }else{
+            if (![ShareUtils hasShareOptionToBeHiddenForFile:self.selectedFileDto]) {
                 DLog(@"Click on index 2 - Delete");
                 [self didSelectDeleteOption];
                 break;

--- a/Owncloud iOs Client/Tabs/SharedTap/SharedViewController.m
+++ b/Owncloud iOs Client/Tabs/SharedTap/SharedViewController.m
@@ -1096,7 +1096,7 @@
 - (NSArray *)setSwipeLeftButtons
 {
     //Check the share options should be presented
-    if ((k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
+    if ([ShareUtils hasShareOptionToBeHidden]) {
         
         return nil;
         

--- a/Owncloud iOs Client/Tabs/SharedTap/SharedViewController.m
+++ b/Owncloud iOs Client/Tabs/SharedTap/SharedViewController.m
@@ -1073,12 +1073,6 @@
 /// @name Set Swipe Right Buttons
 ///-----------------------------------
 
-/**
- * This method set the two right buttons for the swipe
- * Share button in gray
- * UnShare button in red
- *
- */
 - (NSArray *)setSwipeRightButtons
 {
     //No Right buttons
@@ -1089,12 +1083,12 @@
 ///-----------------------------------
 /// @name Set Swipe Left Buttons
 ///-----------------------------------
-
 /**
- * This method is empty now because we don't need left swippe buttons
+ * This method set the two left buttons for the swipe, one or none if it is not allowed to share
+ * Share button in gray
+ * UnShare button in red
  *
  */
-
 - (NSArray *)setSwipeLeftButtonsForFile:(FileDto *)file
 {
     //Check the share options should be presented
@@ -1202,19 +1196,15 @@
     DLog(@"Unshare button pressed");
     
     if (_mShareFileOrFolder) {
-        //Create new object
         self.mShareFileOrFolder = nil;
     }
     
-    //Create new object
     self.mShareFileOrFolder = [ShareFileOrFolder new];
     self.mShareFileOrFolder.delegate = self;
     
     [self.mShareFileOrFolder unshareTheFileByIdRemoteShared:remoteFileId];
     
-    //Refresh the list of share items
     [self performSelector:@selector(refreshSharedItems) withObject:nil afterDelay:0.5];
-    
 }
 
 

--- a/Owncloud iOs Client/Utils/ShareUtils.h
+++ b/Owncloud iOs Client/Utils/ShareUtils.h
@@ -30,6 +30,10 @@
 #pragma mark - capabilities checks
 
 + (BOOL) isPasswordEnforcedCapabilityEnabled;
++ (BOOL) isAllowedReshareForFile:(FileDto *)file;
+
++ (BOOL) hasShareOptionToBeHidden;
++ (BOOL) hasShareOptionToBeHiddenForFile:(FileDto *)file;
 
 + (BOOL) hasOptionAllowEditingToBeShownForFile:(FileDto *)file;
 + (BOOL) hasOptionShowFileListingToBeShownForFile:(FileDto *)file;

--- a/Owncloud iOs Client/Utils/ShareUtils.m
+++ b/Owncloud iOs Client/Utils/ShareUtils.m
@@ -11,6 +11,7 @@
 #import "FileDto.h"
 #import "UtilsUrls.h"
 #import "InfoFileUtils.h"
+#import "constants.h"
 
 #define k_share_link_middle_part_url_before_version_8 @"public.php?service=files&t="
 #define k_share_link_middle_part_url_after_version_8 @"index.php/s/"
@@ -156,6 +157,46 @@
         (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingPasswordEnforcedEnabled) ) {
         
         return YES;
+    }
+    
+    return NO;
+}
+
++ (BOOL)isAllowedReshareForFile:(FileDto *)file {
+    
+    BOOL fileSharedWithMe = [file.permissions rangeOfString:k_permission_shared].location != NSNotFound ;
+    
+    if (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported &&
+        APP_DELEGATE.activeUser.capabilitiesDto &&
+        !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingReSharingEnabled &&
+        fileSharedWithMe) {
+        
+        return NO;
+    }
+    
+    return YES;
+}
+
++(BOOL)hasShareOptionToBeHidden {
+    
+    if ((k_hide_share_options) ||
+        (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported &&
+         APP_DELEGATE.activeUser.capabilitiesDto &&
+         !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
+             return YES;
+         }
+    
+    return NO;
+}
+
++(BOOL)hasShareOptionToBeHiddenForFile:(FileDto *)file {
+    
+    if ((k_hide_share_options) ||
+        (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported &&
+         APP_DELEGATE.activeUser.capabilitiesDto &&
+         (!APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled ||
+          ![ShareUtils isAllowedReshareForFile:file]) )) {
+             return YES;
     }
     
     return NO;


### PR DESCRIPTION
Close #915 
Take into account resharing capability from server to not allow reshare files.

<img src="https://user-images.githubusercontent.com/6570505/31268834-5801940a-aa7e-11e7-9725-7a837d6d4db4.png" alt="alt text" width="188" height="334">  <img src="https://user-images.githubusercontent.com/6570505/31268541-2544eaea-aa7d-11e7-897f-50a9b9d95beb.png" alt="alt text" width="188" height="334">

Files already resharing by link while the capability was enabled, are only allow to unshare:
<img src="https://user-images.githubusercontent.com/6570505/31268895-94a0776e-aa7e-11e7-89c4-61075bc80b65.png" alt="alt text" width="188" height="334">  <img src="https://user-images.githubusercontent.com/6570505/31268897-967b96ae-aa7e-11e7-9bd5-12bd0b5906d8.png" alt="alt text" width="188" height="334">







