### PR TITLE
Reflect forbidden reshare enabled

### DIFF
--- a/Owncloud iOs Client/Files/Preview/DetailView/DetailViewController.m
+++ b/Owncloud iOs Client/Files/Preview/DetailView/DetailViewController.m
@@ -186,7 +186,10 @@
         _titleLabelMarginRightConstraint.constant = 210;
         _updatingProgressMarginUpdatingRightConstraint.constant = 210;
         
-        if ((k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
+        //Check if share link button should be appear.
+        
+        if ([ShareUtils hasShareOptionToBeHiddenForFile:self.file]) {
+            
             [items insertObject:_deleteButtonBar atIndex:indexPosition++];
             
             if ([FileNameUtils isEditTextViewSupportedThisFile:self.file.fileName]) {

--- a/Owncloud iOs Client/Files/Preview/FilePreview/FilePreviewViewController.m
+++ b/Owncloud iOs Client/Files/Preview/FilePreview/FilePreviewViewController.m
@@ -145,7 +145,8 @@ NSString * iPhoneShowNotConnectionWithServerMessageNotification = @"iPhoneShowNo
     }
     
     //Check if share link button should be appear.
-    if ((k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
+    if ([ShareUtils hasShareOptionToBeHiddenForFile:self.file]) {
+        
         NSMutableArray *customItems = [NSMutableArray arrayWithArray:self.toolBar.items];
         [customItems removeObjectIdenticalTo:_shareButtonBar];
         [customItems removeObjectIdenticalTo:_flexibleSpaceAfterShareButtonBar];

--- a/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
+++ b/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
@@ -1381,7 +1381,7 @@
         //Custom cell for SWTableViewCell with right swipe options
         fileCell.containingTableView = tableView;
         [fileCell setCellHeight:fileCell.frame.size.height];
-        fileCell.leftUtilityButtons = [self setSwipeLeftButtons];
+        fileCell.leftUtilityButtons = [self setSwipeLeftButtonsForFile:file];
         
         fileCell.rightUtilityButtons = nil;
         fileCell.delegate = self;
@@ -3384,13 +3384,13 @@
  *
  */
 
-- (NSArray *)setSwipeLeftButtons
+- (NSArray *)setSwipeLeftButtonsForFile:(FileDto *)file
 {
     //Share gray button
     NSMutableArray *rightUtilityButtons = [NSMutableArray new];
     
     BOOL areTwoButtonsInTheSwipe = false;
-    if ( (k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled) ) {
+    if ([ShareUtils hasShareOptionToBeHiddenForFile:file]) {
         //Two buttons
         areTwoButtonsInTheSwipe = true;
     }else{
@@ -3456,7 +3456,7 @@
         }
         case 1:
         {
-            if ((k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
+            if ([ShareUtils hasShareOptionToBeHiddenForFile:self.selectedFileDto]) {
                 DLog(@"Click on index 2 - Delete");
                 [self didSelectDeleteOption];
                 break;
@@ -3469,8 +3469,8 @@
         }
         case 2:
         {
-            if ((k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
-            }else{
+            
+            if (![ShareUtils hasShareOptionToBeHiddenForFile:self.selectedFileDto]) {
                 DLog(@"Click on index 2 - Delete");
                 [self didSelectDeleteOption];
                 break;

--- a/Owncloud iOs Client/Tabs/SharedTap/SharedViewController.m
+++ b/Owncloud iOs Client/Tabs/SharedTap/SharedViewController.m
@@ -832,12 +832,14 @@
         NSArray *topLevelObjects = [[NSBundle mainBundle] loadNibNamed:@"ShareLinkCell" owner:self options:nil];
         // Grab a pointer to the first object (presumably the custom cell, as that's all the XIB should contain).
         sharedLinkCell = (ShareLinkCell *)[topLevelObjects objectAtIndex:0];
-
+        
+        OCSharedDto *sharedDto = [_sharedLinkItems objectAtIndex:indexPath.row];
+        FileDto *file = [ManageFilesDB getFileEqualWithShareDtoPath:sharedDto.path andByUser:APP_DELEGATE.activeUser];
         
         //Custom cell for SWTableViewCell with right swipe options
         sharedLinkCell.containingTableView = tableView;
         [sharedLinkCell setCellHeight:sharedLinkCell.frame.size.height];
-        sharedLinkCell.leftUtilityButtons = [self setSwipeLeftButtons];
+        sharedLinkCell.leftUtilityButtons = [self setSwipeLeftButtonsForFile:file];
         
         sharedLinkCell.rightUtilityButtons = nil;
         sharedLinkCell.delegate = self;
@@ -848,7 +850,6 @@
             [sharedLinkCell.parentPathLabel setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
         }
         
-        OCSharedDto *sharedDto = [_sharedLinkItems objectAtIndex:indexPath.row];
         
         //Set this data
         sharedLinkCell.fileNameLabel.text = [FileNameUtils getTheNameOfSharedPath:sharedDto.path isDirectory:sharedDto.isDirectory];
@@ -1071,12 +1072,6 @@
 /// @name Set Swipe Right Buttons
 ///-----------------------------------
 
-/**
- * This method set the two right buttons for the swipe
- * Share button in gray
- * UnShare button in red
- *
- */
 - (NSArray *)setSwipeRightButtons
 {
     //No Right buttons
@@ -1087,38 +1082,36 @@
 ///-----------------------------------
 /// @name Set Swipe Left Buttons
 ///-----------------------------------
-
 /**
- * This method is empty now because we don't need left swippe buttons
+ * This method set the two left buttons for the swipe, one or none if it is not allowed to share
+ * Share button in gray
+ * UnShare button in red
  *
  */
-
-- (NSArray *)setSwipeLeftButtons
+- (NSArray *)setSwipeLeftButtonsForFile:(FileDto *)file
 {
     //Check the share options should be presented
-    if ((k_hide_share_options) || (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported && APP_DELEGATE.activeUser.capabilitiesDto && !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
+    if ([ShareUtils hasShareOptionToBeHidden]) {
         
         return nil;
         
-    }else{
+    } else {
         
         //Share gray button
         NSMutableArray *rightUtilityButtons = [NSMutableArray new];
         
-        
-        [rightUtilityButtons sw_addUtilityTwoLinesButtonWithColor:
-         [UIColor colorWithRed:0.78f green:0.78f blue:0.8f alpha:1.0]
-                                                            title:NSLocalizedString(@"share_link_long_press", nil)];
+        if (![ShareUtils hasShareOptionToBeHiddenForFile:file]) {
+            //Share gray button
+            [rightUtilityButtons sw_addUtilityTwoLinesButtonWithColor:[UIColor colorWithRed:0.78f green:0.78f blue:0.8f alpha:1.0]
+                                                                title:NSLocalizedString(@"share_link_long_press", nil)];
+        }
         
         //UnShare red button
-        [rightUtilityButtons sw_addUtilityTwoLinesButtonWithColor:
-         [UIColor colorWithRed:1.0f green:0.231f blue:0.188 alpha:1.0f]
+        [rightUtilityButtons sw_addUtilityTwoLinesButtonWithColor:[UIColor colorWithRed:1.0f green:0.231f blue:0.188 alpha:1.0f]
                                                             title:NSLocalizedString(@"unshare_link", nil)];
         
         return rightUtilityButtons;
-        
     }
-    
 }
 
 #pragma mark - SWTableViewDelegate
@@ -1144,52 +1137,28 @@
         case 0: {
             DLog(@"Share Link Option");
             
-            //Get the FileDto
+            [cell hideUtilityButtonsAnimated:YES];
             FileDto *file = [ManageFilesDB getFileEqualWithShareDtoPath:sharedDto.path andByUser:APP_DELEGATE.activeUser];
             
             if (!file) {
                 file = [self getFileNotCatchedBySharedPath:sharedDto];
             }
             
-            if (file) {
+            if ([ShareUtils hasShareOptionToBeHiddenForFile:file]) {
                 
-                ShareMainViewController *share = [[ShareMainViewController alloc] initWithFileDto:file];
-                OCNavigationController *nav = [[OCNavigationController alloc] initWithRootViewController:share];
+                [self unShareLinkOptionSelectedForRemoteFileId:sharedDto.idRemoteShared];
                 
-                if (IS_IPHONE) {
-                    [self presentViewController:nav animated:YES completion:nil];
-                } else {
-                    AppDelegate *app = (AppDelegate*)[[UIApplication sharedApplication] delegate];
-                    nav.modalPresentationStyle = UIModalPresentationFormSheet;
-                    [app.splitViewController presentViewController:nav animated:YES completion:nil];
-                }
+            } else {
+
+                [self shareOptionSelectedForFile:file];
                 
-            }else{
-                [self showError:NSLocalizedString(@"default_not_possible_msg", nil)];
+                [self performSelector:@selector(refreshSharedItems) withObject:nil afterDelay:0.5];
             }
-            
-            [cell hideUtilityButtonsAnimated:YES];
-            
-            [self performSelector:@selector(refreshSharedItems) withObject:nil afterDelay:0.5];
-            
             break;
+            
         } case 1: {
-            DLog(@"Unshare button pressed");
             
-            if (_mShareFileOrFolder) {
-                //Create new object
-                self.mShareFileOrFolder = nil;
-            }
-            
-            //Create new object
-            self.mShareFileOrFolder = [ShareFileOrFolder new];
-            self.mShareFileOrFolder.delegate = self;
-            
-            [self.mShareFileOrFolder unshareTheFileByIdRemoteShared:sharedDto.idRemoteShared];
-            [cell hideUtilityButtonsAnimated:YES];
-            
-            //Refresh the list of share items
-            [self performSelector:@selector(refreshSharedItems) withObject:nil afterDelay:0.5];
+            [self unShareLinkOptionSelectedForRemoteFileId:sharedDto.idRemoteShared];
             
             break;
         }
@@ -1197,6 +1166,45 @@
             break;
     }
 }
+
+- (void) shareOptionSelectedForFile:(FileDto *)file {
+    DLog(@"Share Link Option");
+    
+    if (file) {
+        
+        ShareMainViewController *share = [[ShareMainViewController alloc] initWithFileDto:file];
+        OCNavigationController *nav = [[OCNavigationController alloc] initWithRootViewController:share];
+        
+        if (IS_IPHONE) {
+            [self presentViewController:nav animated:YES completion:nil];
+        } else {
+            AppDelegate *app = (AppDelegate*)[[UIApplication sharedApplication] delegate];
+            nav.modalPresentationStyle = UIModalPresentationFormSheet;
+            [app.splitViewController presentViewController:nav animated:YES completion:nil];
+        }
+        
+    }else{
+        [self showError:NSLocalizedString(@"default_not_possible_msg", nil)];
+    }
+    
+}
+
+- (void) unShareLinkOptionSelectedForRemoteFileId:(NSInteger)remoteFileId {
+    
+    DLog(@"Unshare button pressed");
+    
+    if (_mShareFileOrFolder) {
+        self.mShareFileOrFolder = nil;
+    }
+    
+    self.mShareFileOrFolder = [ShareFileOrFolder new];
+    self.mShareFileOrFolder.delegate = self;
+    
+    [self.mShareFileOrFolder unshareTheFileByIdRemoteShared:remoteFileId];
+    
+    [self performSelector:@selector(refreshSharedItems) withObject:nil afterDelay:0.5];
+}
+
 
 ///-----------------------------------
 /// @name Button of Right Called

--- a/Owncloud iOs Client/Utils/ShareUtils.h
+++ b/Owncloud iOs Client/Utils/ShareUtils.h
@@ -30,6 +30,10 @@
 #pragma mark - capabilities checks
 
 + (BOOL) isPasswordEnforcedCapabilityEnabled;
++ (BOOL) isAllowedReshareForFile:(FileDto *)file;
+
++ (BOOL) hasShareOptionToBeHidden;
++ (BOOL) hasShareOptionToBeHiddenForFile:(FileDto *)file;
 
 + (BOOL) hasOptionAllowEditingToBeShownForFile:(FileDto *)file;
 + (BOOL) hasOptionShowFileListingToBeShownForFile:(FileDto *)file;

--- a/Owncloud iOs Client/Utils/ShareUtils.m
+++ b/Owncloud iOs Client/Utils/ShareUtils.m
@@ -11,6 +11,7 @@
 #import "FileDto.h"
 #import "UtilsUrls.h"
 #import "InfoFileUtils.h"
+#import "constants.h"
 
 #define k_share_link_middle_part_url_before_version_8 @"public.php?service=files&t="
 #define k_share_link_middle_part_url_after_version_8 @"index.php/s/"
@@ -157,6 +158,46 @@
         
         return YES;
     }
+    
+    return NO;
+}
+
++ (BOOL)isAllowedReshareForFile:(FileDto *)file {
+    
+    BOOL fileSharedWithMe = [file.permissions rangeOfString:k_permission_shared].location != NSNotFound ;
+    
+    if (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported &&
+        APP_DELEGATE.activeUser.capabilitiesDto &&
+        !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingReSharingEnabled &&
+        fileSharedWithMe) {
+        
+        return NO;
+    }
+    
+    return YES;
+}
+
++(BOOL)hasShareOptionToBeHidden {
+    
+    if ((k_hide_share_options) ||
+        (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported &&
+         APP_DELEGATE.activeUser.capabilitiesDto &&
+         !APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled)) {
+            return YES;
+        }
+    
+    return NO;
+}
+
++(BOOL)hasShareOptionToBeHiddenForFile:(FileDto *)file {
+    
+    if ((k_hide_share_options) ||
+        (APP_DELEGATE.activeUser.hasCapabilitiesSupport == serverFunctionalitySupported &&
+         APP_DELEGATE.activeUser.capabilitiesDto &&
+         (!APP_DELEGATE.activeUser.capabilitiesDto.isFilesSharingAPIEnabled ||
+          ![ShareUtils isAllowedReshareForFile:file]) )) {
+             return YES;
+         }
     
     return NO;
 }


### PR DESCRIPTION
Close #915 
Take into account resharing capability from server to not allow reshare files.

<img src="https://user-images.githubusercontent.com/6570505/31268834-5801940a-aa7e-11e7-9725-7a837d6d4db4.png" alt="alt text" width="188" height="334">  <img src="https://user-images.githubusercontent.com/6570505/31268541-2544eaea-aa7d-11e7-897f-50a9b9d95beb.png" alt="alt text" width="188" height="334">

Files already resharing by link while the capability was enabled, are only allow to unshare:
<img src="https://user-images.githubusercontent.com/6570505/31268895-94a0776e-aa7e-11e7-89c4-61075bc80b65.png" alt="alt text" width="188" height="334">  <img src="https://user-images.githubusercontent.com/6570505/31268897-967b96ae-aa7e-11e7-9bd5-12bd0b5906d8.png" alt="alt text" width="188" height="334">