### PR TITLE
Improved error messages in file list view, show warnings on the top

### DIFF
--- a/Owncloud iOs Client/Tabs/FileTab/FilesViewController.h
+++ b/Owncloud iOs Client/Tabs/FileTab/FilesViewController.h
@@ -47,6 +47,8 @@
 #import "SelectFolderNavigation.h"
 #import "ManageFavorites.h"
 #import "DetectUserData.h"
+#import "TSMessage.h"
+#import "TSMessageView.h"
 
 #ifdef CONTAINER_APP
 #import "Owncloud_iOs_Client-Swift.h"
@@ -64,7 +66,7 @@
 
 @interface FilesViewController : UIViewController
 <UITableViewDelegate, UITableViewDataSource, UIActionSheetDelegate,
-ELCImagePickerControllerDelegate, UISearchBarDelegate, UIAlertViewDelegate, MBProgressHUDDelegate, UITextFieldDelegate, DeleteFileDelegate, OpenWithDelegate, DownloadViewControllerDelegate, CheckAccessToServerDelegate, RenameDelegate, MoveFileDelegate, SWTableViewCellDelegate, ManageNetworkErrorsDelegate, ManageFavoritesDelegate>
+ELCImagePickerControllerDelegate, UISearchBarDelegate, UIAlertViewDelegate, MBProgressHUDDelegate, UITextFieldDelegate, DeleteFileDelegate, OpenWithDelegate, DownloadViewControllerDelegate, CheckAccessToServerDelegate, RenameDelegate, MoveFileDelegate, SWTableViewCellDelegate, ManageNetworkErrorsDelegate, ManageFavoritesDelegate, TSMessageViewProtocol>
 
 //Table view
 @property(nonatomic, strong) IBOutlet UITableView *tableView;

--- a/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
+++ b/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
@@ -1034,8 +1034,22 @@
     
     //Run UI Updates
     [TSMessage setDelegate:self];
-    [TSMessage showNotificationInViewController:self title:message subtitle:nil type:TSMessageNotificationTypeWarning];
     
+    if (self.navigationController.navigationBarHidden){
+        [self.navigationController setNavigationBarHidden:NO];
+    }
+    
+    [TSMessage showNotificationInViewController:self.navigationController
+                                          title:message
+                                       subtitle:nil
+                                          image:nil
+                                           type:TSMessageNotificationTypeWarning
+                                       duration:TSMessageNotificationDurationAutomatic
+                                       callback:nil
+                                    buttonTitle:nil
+                                 buttonCallback:nil
+                                     atPosition:TSMessageNotificationPositionNavBarOverlay
+                           canBeDismissedByUser:YES];
 }
 
 #pragma mark - TSMessage Delegate

--- a/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
+++ b/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
@@ -1027,6 +1027,27 @@
     [_alert show];
 }
 
+
+#pragma mark - TSMessages
+
+- (void)showWarningMessageWithText: (NSString *) message {
+    
+    //Run UI Updates
+    [TSMessage setDelegate:self];
+    [TSMessage showNotificationInViewController:self title:message subtitle:nil type:TSMessageNotificationTypeWarning];
+    
+}
+
+#pragma mark - TSMessage Delegate
+
+- (void)customizeMessageView:(TSMessageView *)messageView
+{
+    messageView.alpha = messageAlpha;
+    messageView.duration = messageDuration;
+}
+
+
+
 #pragma mark - UITextFieldDelegate methods
 
 - (BOOL)textFieldShouldBeginEditing:(UITextField *)textField{
@@ -1683,7 +1704,7 @@
             [self goToFolderWithoutCheck];
         } else {
             
-            [self performSelectorOnMainThread:@selector(showAlertView:)
+            [self performSelectorOnMainThread:@selector(showWarningMessageWithText:)
                                    withObject:NSLocalizedString(@"not_possible_connect_to_server", nil)
                                 waitUntilDone:YES];
             [self endLoading];
@@ -2298,7 +2319,7 @@
                 case 3:
                     
                     if (self.isCurrentFolderSonOfFavoriteFolder) {
-                        [self performSelectorOnMainThread:@selector(showAlertView:)
+                        [self performSelectorOnMainThread:@selector(showWarningMessageWithText:)
                                                withObject:NSLocalizedString(@"parent_folder_is_available_offline_folder_child", nil)
                                             waitUntilDone:YES];
                     } else {
@@ -2320,7 +2341,7 @@
                     if (_selectedFileDto.isDownload || [[CheckAccessToServer sharedManager] isNetworkIsReachable]){
                         [self didSelectOpenWithOptionAndFile:_selectedFileDto];
                     } else {
-                        [self performSelectorOnMainThread:@selector(showAlertView:)
+                        [self performSelectorOnMainThread:@selector(showWarningMessageWithText:)
                                                withObject:NSLocalizedString(@"not_possible_connect_to_server", nil)
                                             waitUntilDone:YES];
                     }
@@ -2333,7 +2354,7 @@
                     break;
                 case 3:
                     if (self.isCurrentFolderSonOfFavoriteFolder) {
-                        [self performSelectorOnMainThread:@selector(showAlertView:)
+                        [self performSelectorOnMainThread:@selector(showWarningMessageWithText:)
                                                withObject:NSLocalizedString(@"parent_folder_is_available_offline_file_child", nil)
                                             waitUntilDone:YES];
                     } else {
@@ -3285,7 +3306,7 @@
  */
 - (void)showError:(NSString *) message {
     
-    [self performSelectorOnMainThread:@selector(showAlertView:)
+    [self performSelectorOnMainThread:@selector(showWarningMessageWithText:)
                                withObject:message
                             waitUntilDone:YES];
   
@@ -3340,8 +3361,8 @@
         DLog(@"Ok, we have connection to the server");
     } else {        
         //Error msg
-        //Call showAlertView in main thread
-        [self performSelectorOnMainThread:@selector(showAlertView:)
+        //Call show error in main thread
+        [self performSelectorOnMainThread:@selector(showWarningMessageWithText:)
                                withObject:NSLocalizedString(@"not_possible_connect_to_server", nil)
                             waitUntilDone:YES];
     }

--- a/Owncloud iOs Client/Tabs/FileTab/Share/ShareSearchUserViewController.m
+++ b/Owncloud iOs Client/Tabs/FileTab/Share/ShareSearchUserViewController.m
@@ -36,8 +36,6 @@
 #define loadingVisibleSearchDelay 2.0
 #define loadingVisibleSortDelay 0.1
 #define searchResultsPerPage 30
-#define messageAlpha 0.96
-#define messageDuration 3.5
 #define shareSearchUserLaunchRequestDelay 1.0
 
 @interface ShareSearchUserViewController ()

--- a/Owncloud iOs Client/Utils/constants.h
+++ b/Owncloud iOs Client/Utils/constants.h
@@ -81,5 +81,6 @@
 #define k_max_number_options_sort_menu 2
 #define k_max_number_options_account_menu 3
 
-
-
+//Customize top warning Messages view (TSMessage)
+#define messageAlpha 0.96
+#define messageDuration 3.5


### PR DESCRIPTION
First improve to make less intrusive all network error messages in file list view. 
Related to https://github.com/owncloud/ios/issues/869

Network errors on the file list view will appear on the top of the view and will disappear automatically without the user interaction.

**Updated** Show over the navigation bar

<img src="https://user-images.githubusercontent.com/6570505/32852108-44cb673e-ca37-11e7-9d9d-6c9b3e4e90d8.PNG" alt="alt text" width="188" height="334">  <img src="https://user-images.githubusercontent.com/6570505/32887021-d7110f50-cac2-11e7-99cc-9fe9461d07b4.PNG" alt="alt text" width="188" height="334">



cc: @michaelstingl @jesmrec 




