### PR TITLE
Fix migrate to other URL

### DIFF
--- a/Owncloud iOs Client/AppDelegate.m
+++ b/Owncloud iOs Client/AppDelegate.m
@@ -5,7 +5,7 @@
 //  Created by Javier Gonzalez on 7/11/12.
 
 /*
- Copyright (C) 2017, ownCloud GmbH.
+ Copyright (C) 2018, ownCloud GmbH.
  This code is covered by the GNU Public License Version 3.
  For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
  You should have received a copy of this license
@@ -148,8 +148,6 @@ float shortDelay = 0.3;
     
     [self showSplashScreenFake];
     
-    [CheckFeaturesSupported updateServerFeaturesAndCapabilitiesOfActiveUser];
-    
     //Needed to use on background tasks
     if (!k_is_sso_active) {
         [[UIApplication sharedApplication] setMinimumBackgroundFetchInterval:UIApplicationBackgroundFetchIntervalMinimum];
@@ -178,18 +176,25 @@ float shortDelay = 0.3;
     
     if (user) {
         self.activeUser = user;
-        [UtilsCookies deleteCurrentSystemCookieStorageAndRestoreTheCookiesOfActiveUser];
         
         ((CheckAccessToServer*)[CheckAccessToServer sharedManager]).delegate = self;
         [[CheckAccessToServer sharedManager] isConnectionToTheServerByUrl:user.url withTimeout:k_timeout_fast];
-        
-        ManageAccounts *manageAccounts = [ManageAccounts new];
-        [manageAccounts updateDisplayNameOfUserWithUser:self.activeUser];
-        
-        //if we are migrating url not relaunch sync
+
+        //if we are migrating url not relaunch sync, neither update cookies and server checks
         if (![UtilsUrls isNecessaryUpdateToPredefinedUrlByPreviousUrl:self.activeUser.predefinedUrl]) {
+            
+            [CheckFeaturesSupported updateServerFeaturesAndCapabilitiesOfActiveUser];
+            
+            [UtilsCookies deleteCurrentSystemCookieStorageAndRestoreTheCookiesOfActiveUser];
+            
+            ManageAccounts *manageAccounts = [ManageAccounts new];
+            [manageAccounts updateDisplayNameOfUserWithUser:self.activeUser];
+            
             //Update favorites files if there are active user
             [self performSelector:@selector(launchProcessToSyncAllFavorites) withObject:nil afterDelay:fiveSecondsDelay];
+            
+        } else {
+             [UtilsCookies deleteAllCookiesOfActiveUser];
         }
         
     } else if (k_show_main_help_guide && [ManageDB getShowHelpGuide]) {

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -7,7 +7,7 @@
 //
 
 /*
- Copyright (C) 2017, ownCloud GmbH.
+ Copyright (C) 2018, ownCloud GmbH.
  This code is covered by the GNU Public License Version 3.
  For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
  You should have received a copy of this license
@@ -846,7 +846,11 @@ public enum TextfieldType: String {
 // MARK: 'private' methods
     
     func detectUserDataAndValidate(credentials: OCCredentialsDto, serverPath: String) {
+        if loginMode == .migrate {
+            UtilsCookies.deleteAllCookiesOfActiveUser()
+        }
         
+        sleep(UInt32(2))
         DetectUserData .getUserDisplayName(ofServer: serverPath, credentials: credentials) { (serverUserID, displayName, error) in
             
             if (serverUserID != nil && displayName != nil) {
@@ -897,12 +901,13 @@ public enum TextfieldType: String {
                         let newUser = UserDto()
                         if self.loginMode == .migrate {
                             newUser.userId = self.user!.userId
+                            newUser.predefinedUrl = k_default_url_server
                         }
                         newUser.url = self.validatedServerURL
                         newUser.username = credentials.userName
                         newUser.ssl = self.validatedServerURL.hasPrefix("https")
                         newUser.urlRedirected = app.urlServerRedirected
-                        newUser.predefinedUrl = k_default_url_server
+                        newUser.activeaccount = true
                         
                         self.user = newUser.copy() as? UserDto
                     }

--- a/Owncloud iOs Client/Utils/UtilsCookies.h
+++ b/Owncloud iOs Client/Utils/UtilsCookies.h
@@ -6,7 +6,7 @@
 //
 
 /*
- Copyright (C) 2016, ownCloud GmbH.
+ Copyright (C) 2018, ownCloud GmbH.
  This code is covered by the GNU Public License Version 3.
  For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
  You should have received a copy of this license
@@ -34,5 +34,7 @@
 + (void) deleteCurrentSystemCookieStorageAndRestoreTheCookiesOfActiveUser;
 
 + (void) saveActiveUserCookiesAndRestoreCookiesOfUser:(UserDto *)user;
+
++ (void) deleteAllCookiesOfActiveUser;
 
 @end

--- a/Owncloud iOs Client/Utils/UtilsCookies.m
+++ b/Owncloud iOs Client/Utils/UtilsCookies.m
@@ -6,7 +6,7 @@
 //
 
 /*
- Copyright (C) 2016, ownCloud GmbH.
+ Copyright (C) 2018, ownCloud GmbH.
  This code is covered by the GNU Public License Version 3.
  For distribution utilizing Apple mechanisms please see https://owncloud.org/contribute/iOS-license-exception/
  You should have received a copy of this license
@@ -116,6 +116,16 @@
     [self saveCurrentOfActiveUserAndClean];
 
     [self restoreCookiesOfUser:user];
+}
+
++ (void) deleteAllCookiesOfActiveUser {
+    AppDelegate *app = (AppDelegate *)[[UIApplication sharedApplication]delegate];
+
+    //1- Clean the cookies storage
+    [UtilsFramework deleteAllCookies];
+    
+    //2- Try to Delete the cookies of the active user
+    [ManageCookiesStorageDB deleteCookiesByUser:app.activeUser];
 }
 
 @end


### PR DESCRIPTION
### Steps to reproduce
1. Select to migrate URL
2. Upgrade iOS OC version
3. Enter new credentials

### Expected behaviour
After renew credentials go to file list view

### Actual behaviour
After renew credentials app keeps in the login view.

Regression3.7.0

- [ ] [READY TO TEST]

cc: @jesmrec 