### PR TITLE
Fix crash save image into camera roll iOS11

### DIFF
--- a/OC Share Sheet/Info.plist
+++ b/OC Share Sheet/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.2</string>
+	<string>3.7.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.1</string>
+	<string>1.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>

--- a/Owncloud iOs Client/AppDelegate.m
+++ b/Owncloud iOs Client/AppDelegate.m
@@ -1765,13 +1765,8 @@ float shortDelay = 0.3;
     if (self.presentFilesViewController){
         //Close the openWith option in FileViewController
         if (self.presentFilesViewController.openWith) {
-            if (k_use_open_with_UIDocumentInteractionController) {
-                [self.presentFilesViewController.openWith.documentInteractionController dismissMenuAnimated:NO];
-                self.presentFilesViewController.openWith.documentInteractionController = nil;
-            } else {
-                [self.presentFilesViewController.openWith.activityView dismissViewControllerAnimated:NO completion:nil];
-                self.presentFilesViewController.openWith.activityView = nil;
-            }
+            [self.presentFilesViewController.openWith.documentInteractionController dismissMenuAnimated:NO];
+            self.presentFilesViewController.openWith.documentInteractionController = nil;
         }
         //Close the delete option in FilesViewController
         if (self.presentFilesViewController.mDeleteFile.popupQuery) {

--- a/Owncloud iOs Client/Files/Preview/DetailView/DetailViewController.m
+++ b/Owncloud iOs Client/Files/Preview/DetailView/DetailViewController.m
@@ -845,11 +845,7 @@
     
     _titleLabel.text = @"";
 
-    if (k_use_open_with_UIDocumentInteractionController) {
-        [_openWith.documentInteractionController dismissMenuAnimated:YES];
-    } else {
-        [_openWith.activityPopoverController dismissPopoverAnimated:YES];
-    }
+    [_openWith.documentInteractionController dismissMenuAnimated:YES];
     
     [self removeThePreviousViews];
     
@@ -1058,16 +1054,9 @@
  */
 - (IBAction)didPressShareLinkButton:(id)sender {
     DLog(@"Share button clicked");
-    
-    if (k_use_open_with_UIDocumentInteractionController) {
 
-        if (_openWith && _openWith.documentInteractionController) {
-            [_openWith.documentInteractionController dismissMenuAnimated:YES];
-        }
-    } else {
-        if (_openWith && _openWith.activityView) {
-            [_openWith.activityPopoverController dismissPopoverAnimated:YES];
-        }
+    if (_openWith && _openWith.documentInteractionController) {
+        [_openWith.documentInteractionController dismissMenuAnimated:YES];
     }
     
     DLog(@"Share Link Option");
@@ -1747,11 +1736,7 @@
     
     if (_openWith) {
         
-        if (k_use_open_with_UIDocumentInteractionController) {
-            [_openWith.documentInteractionController dismissMenuAnimated:NO];
-        } else {
-            [_openWith.activityPopoverController dismissPopoverAnimated:NO];
-        }
+        [_openWith.documentInteractionController dismissMenuAnimated:NO];
     }
     
 }

--- a/Owncloud iOs Client/Network/Server Version Checks/CheckFeaturesSupported.m
+++ b/Owncloud iOs Client/Network/Server Version Checks/CheckFeaturesSupported.m
@@ -59,6 +59,7 @@
                 app.activeUser.capabilitiesDto =  [ManageCapabilitiesDB getCapabilitiesOfUserId:app.activeUser.userId];
             }];
         }
+    });
 }
 
 + (void) updateServerFeaturesOfActiveUserForVersion:(NSString *)versionString {

--- a/Owncloud iOs Client/Network/Server Version Checks/CheckFeaturesSupported.m
+++ b/Owncloud iOs Client/Network/Server Version Checks/CheckFeaturesSupported.m
@@ -59,7 +59,6 @@
                 app.activeUser.capabilitiesDto =  [ManageCapabilitiesDB getCapabilitiesOfUserId:app.activeUser.userId];
             }];
         }
-    });
 }
 
 + (void) updateServerFeaturesOfActiveUserForVersion:(NSString *)versionString {

--- a/Owncloud iOs Client/Owncloud iOs Client-Info.plist
+++ b/Owncloud iOs Client/Owncloud iOs Client-Info.plist
@@ -91,7 +91,11 @@
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>Used to instantly upload your new photos after a significant change in your location</string>
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Upload your selected photos to your account</string>
+	<string>Used to upload your selected photos to your account</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>Used to save your selected photo to your camera roll</string>
+	<key>NSFaceIDUsageDescription</key>
+	<string>Used to allow you unlock your app with your face</string>
 	<key>UIApplicationExitsOnSuspend</key>
 	<false/>
 	<key>UIBackgroundModes</key>

--- a/Owncloud iOs Client/Owncloud iOs Client-Info.plist
+++ b/Owncloud iOs Client/Owncloud iOs Client-Info.plist
@@ -49,7 +49,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.2</string>
+	<string>3.7.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>
@@ -66,7 +66,7 @@
 		</dict>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.0.1</string>
+	<string>1.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>

--- a/Owncloud iOs Client/SupportingFiles/en.lproj/InfoPlist.strings
+++ b/Owncloud iOs Client/SupportingFiles/en.lproj/InfoPlist.strings
@@ -6,7 +6,9 @@
 
 */
 
-
-"NSPhotoLibraryUsageDescription" = "Upload your selected photos to your account";
+"NSLocationAlwaysAndWhenInUseUsageDescription" = "Used to instantly upload your new photos after a significant change in your location";
 "NSLocationAlwaysUsageDescription" = "Used to instantly upload your new photos after a significant change in your location";
 "NSLocationWhenInUseUsageDescription" = "Used to instantly upload your new photos after a significant change in your location";
+"NSPhotoLibraryUsageDescription" = "Upload your selected photos to your account";
+"NSPhotoLibraryAddUsageDescription" = "Used to save your selected photo to your camera roll";
+"NSFaceIDUsageDescription" = "Used to allow you unlock your app with your face";

--- a/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
+++ b/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
@@ -624,11 +624,7 @@
 - (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration{
     
     if (self.openWith && !IS_IPHONE) {
-        if (k_use_open_with_UIDocumentInteractionController) {
-            [self.openWith.documentInteractionController dismissMenuAnimated:NO];
-        } else {
-            [self.openWith.activityView dismissViewControllerAnimated:NO completion:nil];
-        }
+        [self.openWith.documentInteractionController dismissMenuAnimated:NO];
     }
     
     if (self.plusActionSheet) {
@@ -2547,11 +2543,7 @@
             if (_selectedIndexPath) {
                 cell = [_tableView cellForRowAtIndexPath:_selectedIndexPath];
                 _openWith.parentView =_tableView;
-                if (k_use_open_with_UIDocumentInteractionController) {
-                    _openWith.cellFrame = [self.tableView rectForRowAtIndexPath:self.selectedIndexPath];
-                } else {
-                    _openWith.cellFrame = cell.frame;
-                }
+                _openWith.cellFrame = [self.tableView rectForRowAtIndexPath:self.selectedIndexPath];
                 _openWith.isTheParentViewACell = YES;
                 
             } else {

--- a/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.h
+++ b/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.h
@@ -37,6 +37,13 @@
 @property(nonatomic,weak) __weak id<OpenWithDelegate> delegate; 
 @property(nonatomic, strong) UIView *parentView;
 @property(nonatomic, strong) UIDocumentInteractionController *documentInteractionController;
+
+/* Use UIActivityViewController and UIPopoverController instead of UIDocumentInteractionController
+ *  for open with option until fix for UIDocumentInteractionController in iOS11
+ */
+@property(nonatomic, strong) UIActivityViewController *activityView;
+@property (nonatomic, strong) UIPopoverController *activityPopoverController;
+
 @property(nonatomic, strong) UIBarButtonItem *parentButton;
 @property(nonatomic, strong) Download *download;
 @property(nonatomic, strong) NSString *currentLocalFolder;

--- a/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.h
+++ b/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.h
@@ -37,13 +37,6 @@
 @property(nonatomic,weak) __weak id<OpenWithDelegate> delegate; 
 @property(nonatomic, strong) UIView *parentView;
 @property(nonatomic, strong) UIDocumentInteractionController *documentInteractionController;
-
-/* Use UIActivityViewController and UIPopoverController instead of UIDocumentInteractionController
- *  for open with option until fix for UIDocumentInteractionController in iOS11
- */
-@property(nonatomic, strong) UIActivityViewController *activityView;
-@property (nonatomic, strong) UIPopoverController *activityPopoverController;
-
 @property(nonatomic, strong) UIBarButtonItem *parentButton;
 @property(nonatomic, strong) Download *download;
 @property(nonatomic, strong) NSString *currentLocalFolder;

--- a/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
+++ b/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
@@ -90,96 +90,26 @@
     if (file.localFolder) {
         
         DLog(@"File path is %@", file.localFolder);
-        if (!IS_IOS11) {
-            //Pass path to url
-            NSURL *url = [NSURL fileURLWithPath:file.localFolder];
-            self.documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:url];
-            [self.documentInteractionController setDelegate:self];
+        
+        //Pass path to url
+        NSURL *url = [NSURL fileURLWithPath:file.localFolder];
+        self.documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:url];
+        [self.documentInteractionController setDelegate:self];
+        
+        if (_isTheParentViewACell) {
             
-            if (_isTheParentViewACell) {
-                
-                [self.documentInteractionController presentOptionsMenuFromRect:self.cellFrame inView:self.parentView animated:YES];
-                
-            } else {
-                
-                if (IS_IPHONE) {
-                    [self.documentInteractionController presentOptionsMenuFromRect:CGRectZero inView:self.parentView animated:YES];
-                    
-                } else {
-                    [self.documentInteractionController presentOptionsMenuFromBarButtonItem:self.parentButton animated:YES];
-                }
-            }
-        }else {
+            [self.documentInteractionController presentOptionsMenuFromRect:self.cellFrame inView:self.parentView animated:YES];
             
-            AppDelegate *app = (AppDelegate *)[[UIApplication sharedApplication]delegate];
-            
-            DLog(@"File path is %@", file.localFolder);
-            
-            //Pass path to url
-            NSURL *url = [NSURL fileURLWithPath:file.localFolder];
-            
-            TTOpenInAppActivity *openInAppActivity;
-            
-            if (_isTheParentViewACell) {
-                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andRect:_cellFrame];
-                
-            }else{
-                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andBarButtonItem:self.parentButton];
-            }
-            
-            
-            if (self.activityView) {
-                [self.activityView dismissViewControllerAnimated:YES completion:nil];
-                self.activityView = nil;
-            }
-            
-            if (self.activityPopoverController) {
-                [self.activityPopoverController dismissPopoverAnimated:YES];
-                self.activityPopoverController = nil;
-            }
-            
-            self.activityView = [[UIActivityViewController alloc] initWithActivityItems:@[url] applicationActivities:@[openInAppActivity]];
+        } else {
             
             if (IS_IPHONE) {
+                [self.documentInteractionController presentOptionsMenuFromRect:CGRectZero inView:self.parentView animated:YES];
                 
-                openInAppActivity.superViewController = self.activityView;
-                
-                [app.ocTabBarController presentViewController:self.activityView animated:YES completion:nil];
             } else {
-                
-                if (self.activityPopoverController) {
-                    [self.activityPopoverController setContentViewController:self.activityView];
-                } else {
-                    self.activityPopoverController = [[UIPopoverController alloc] initWithContentViewController:self.activityView];
-                }
-                
-                openInAppActivity.superViewController = self.activityPopoverController;
-                
-                if (_isTheParentViewACell && IS_PORTRAIT) {
-                    
-                    [self.activityPopoverController presentPopoverFromRect:CGRectMake(app.detailViewController.view.frame.size.width/2, app.detailViewController.view.frame.size.width/2, 100, 100) inView:app.detailViewController.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-                    
-                }else{
-                    
-                    if (_isTheParentViewACell) {
-                        //Present view from cell from file list
-                        [self.activityPopoverController presentPopoverFromRect:_cellFrame inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
-                        
-                    } else if (_parentButton) {
-                        //Present view from bar button item
-                        [self.activityPopoverController presentPopoverFromBarButtonItem:_parentButton permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-                        
-                    } else {
-                        //Present  view from rect
-                        [self.activityPopoverController presentPopoverFromRect:CGRectMake(100, 100, 200, 400) inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
-                    }
-                }
+                [self.documentInteractionController presentOptionsMenuFromBarButtonItem:self.parentButton animated:YES];
             }
-            
         }
     }
-    
-    
 }
 
 #pragma mark - UIDocumentInteractionControllerDelegate methods

--- a/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
+++ b/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
@@ -90,26 +90,96 @@
     if (file.localFolder) {
         
         DLog(@"File path is %@", file.localFolder);
-        
-        //Pass path to url
-        NSURL *url = [NSURL fileURLWithPath:file.localFolder];
-        self.documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:url];
-        [self.documentInteractionController setDelegate:self];
-        
-        if (_isTheParentViewACell) {
+        if (!IS_IOS11) {
+            //Pass path to url
+            NSURL *url = [NSURL fileURLWithPath:file.localFolder];
+            self.documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:url];
+            [self.documentInteractionController setDelegate:self];
             
-            [self.documentInteractionController presentOptionsMenuFromRect:self.cellFrame inView:self.parentView animated:YES];
-            
-        } else {
-            
-            if (IS_IPHONE) {
-                [self.documentInteractionController presentOptionsMenuFromRect:CGRectZero inView:self.parentView animated:YES];
+            if (_isTheParentViewACell) {
+                
+                [self.documentInteractionController presentOptionsMenuFromRect:self.cellFrame inView:self.parentView animated:YES];
                 
             } else {
-                [self.documentInteractionController presentOptionsMenuFromBarButtonItem:self.parentButton animated:YES];
+                
+                if (IS_IPHONE) {
+                    [self.documentInteractionController presentOptionsMenuFromRect:CGRectZero inView:self.parentView animated:YES];
+                    
+                } else {
+                    [self.documentInteractionController presentOptionsMenuFromBarButtonItem:self.parentButton animated:YES];
+                }
             }
+        }else {
+            
+            AppDelegate *app = (AppDelegate *)[[UIApplication sharedApplication]delegate];
+            
+            DLog(@"File path is %@", file.localFolder);
+            
+            //Pass path to url
+            NSURL *url = [NSURL fileURLWithPath:file.localFolder];
+            
+            TTOpenInAppActivity *openInAppActivity;
+            
+            if (_isTheParentViewACell) {
+                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andRect:_cellFrame];
+                
+            }else{
+                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andBarButtonItem:self.parentButton];
+            }
+            
+            
+            if (self.activityView) {
+                [self.activityView dismissViewControllerAnimated:YES completion:nil];
+                self.activityView = nil;
+            }
+            
+            if (self.activityPopoverController) {
+                [self.activityPopoverController dismissPopoverAnimated:YES];
+                self.activityPopoverController = nil;
+            }
+            
+            self.activityView = [[UIActivityViewController alloc] initWithActivityItems:@[url] applicationActivities:@[openInAppActivity]];
+            
+            if (IS_IPHONE) {
+                
+                openInAppActivity.superViewController = self.activityView;
+                
+                [app.ocTabBarController presentViewController:self.activityView animated:YES completion:nil];
+            } else {
+                
+                if (self.activityPopoverController) {
+                    [self.activityPopoverController setContentViewController:self.activityView];
+                } else {
+                    self.activityPopoverController = [[UIPopoverController alloc] initWithContentViewController:self.activityView];
+                }
+                
+                openInAppActivity.superViewController = self.activityPopoverController;
+                
+                if (_isTheParentViewACell && IS_PORTRAIT) {
+                    
+                    [self.activityPopoverController presentPopoverFromRect:CGRectMake(app.detailViewController.view.frame.size.width/2, app.detailViewController.view.frame.size.width/2, 100, 100) inView:app.detailViewController.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+                    
+                }else{
+                    
+                    if (_isTheParentViewACell) {
+                        //Present view from cell from file list
+                        [self.activityPopoverController presentPopoverFromRect:_cellFrame inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
+                        
+                    } else if (_parentButton) {
+                        //Present view from bar button item
+                        [self.activityPopoverController presentPopoverFromBarButtonItem:_parentButton permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+                        
+                    } else {
+                        //Present  view from rect
+                        [self.activityPopoverController presentPopoverFromRect:CGRectMake(100, 100, 200, 400) inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
+                    }
+                }
+            }
+            
         }
     }
+    
+    
 }
 
 #pragma mark - UIDocumentInteractionControllerDelegate methods

--- a/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
+++ b/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
@@ -25,6 +25,7 @@
 #import "Customization.h"
 
 
+
 @implementation OpenWith
 
 
@@ -110,7 +111,6 @@
             }
         }else {
             
-            
             AppDelegate *app = (AppDelegate *)[[UIApplication sharedApplication]delegate];
             
             DLog(@"File path is %@", file.localFolder);
@@ -118,93 +118,63 @@
             //Pass path to url
             NSURL *url = [NSURL fileURLWithPath:file.localFolder];
             
+            TTOpenInAppActivity *openInAppActivity;
             
-            UIActivityItemProvider *activityProvider = [[UIActivityItemProvider alloc] initWithPlaceholderItem:url];
-            NSArray *items = @[activityProvider,url];
-            
-            NSMutableArray *activities = [NSMutableArray new];
-            
-            
-            self.activityView = [[UIActivityViewController alloc]
-                                                      initWithActivityItems:items
-                                                      applicationActivities:activities];
-            
-                [self.activityView setExcludedActivityTypes:
-                 @[UIActivityTypeAssignToContact,
-                   UIActivityTypeCopyToPasteboard,
-                   UIActivityTypePrint,
-                   UIActivityTypeSaveToCameraRoll,
-                   UIActivityTypePostToWeibo]];
-            
-            if (IS_IPHONE) {
-
-                [app.ocTabBarController presentViewController:self.activityView animated:YES completion:nil];
+            if (_isTheParentViewACell) {
+                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andRect:_cellFrame];
+                
+            }else{
+                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andBarButtonItem:self.parentButton];
             }
             
-//            else {
-//
-//                self.activityPopoverController = [[UIPopoverController alloc] initWithContentViewController:self.activityView];
-//
-//                [self.activityPopoverController presentPopoverFromRect:CGRectMake(100, 100, 200, 400) inView:sender permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-//            }
             
-//            TTOpenInAppActivity *openInAppActivity;
-//
-//            if (_isTheParentViewACell) {
-//                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andRect:_cellFrame];
-//
-//            }else{
-//                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andBarButtonItem:self.parentButton];
-//            }
-//
-//
-//            if (self.activityView) {
-//                [self.activityView dismissViewControllerAnimated:YES completion:nil];
-//                self.activityView = nil;
-//            }
-//
-//            if (self.activityPopoverController) {
-//                [self.activityPopoverController dismissPopoverAnimated:YES];
-//                self.activityPopoverController = nil;
-//            }
-//
-//            self.activityView = [[UIActivityViewController alloc] initWithActivityItems:@[url] applicationActivities:@[openInAppActivity]];
-//
-//            if (IS_IPHONE) {
-//
-//                openInAppActivity.superViewController = self.activityView;
-//
-//                [app.ocTabBarController presentViewController:self.activityView animated:YES completion:nil];
-//            } else {
-//
-//                if (self.activityPopoverController) {
-//                    [self.activityPopoverController setContentViewController:self.activityView];
-//                } else {
-//                    self.activityPopoverController = [[UIPopoverController alloc] initWithContentViewController:self.activityView];
-//                }
-//
-//                openInAppActivity.superViewController = self.activityPopoverController;
-//
-//                if (_isTheParentViewACell && IS_PORTRAIT) {
-//
-//                    [self.activityPopoverController presentPopoverFromRect:CGRectMake(app.detailViewController.view.frame.size.width/2, app.detailViewController.view.frame.size.width/2, 100, 100) inView:app.detailViewController.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-//
-//                }else{
-//
-//                    if (_isTheParentViewACell) {
-//                        //Present view from cell from file list
-//                        [self.activityPopoverController presentPopoverFromRect:_cellFrame inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
-//
-//                    } else if (_parentButton) {
-//                        //Present view from bar button item
-//                        [self.activityPopoverController presentPopoverFromBarButtonItem:_parentButton permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-//
-//                    } else {
-//                        //Present  view from rect
-//                        [self.activityPopoverController presentPopoverFromRect:CGRectMake(100, 100, 200, 400) inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
-//                    }
-//                }
-//            }
+            if (self.activityView) {
+                [self.activityView dismissViewControllerAnimated:YES completion:nil];
+                self.activityView = nil;
+            }
+            
+            if (self.activityPopoverController) {
+                [self.activityPopoverController dismissPopoverAnimated:YES];
+                self.activityPopoverController = nil;
+            }
+            
+            self.activityView = [[UIActivityViewController alloc] initWithActivityItems:@[url] applicationActivities:@[openInAppActivity]];
+            
+            if (IS_IPHONE) {
+                
+                openInAppActivity.superViewController = self.activityView;
+                
+                [app.ocTabBarController presentViewController:self.activityView animated:YES completion:nil];
+            } else {
+                
+                if (self.activityPopoverController) {
+                    [self.activityPopoverController setContentViewController:self.activityView];
+                } else {
+                    self.activityPopoverController = [[UIPopoverController alloc] initWithContentViewController:self.activityView];
+                }
+                
+                openInAppActivity.superViewController = self.activityPopoverController;
+                
+                if (_isTheParentViewACell && IS_PORTRAIT) {
+                    
+                    [self.activityPopoverController presentPopoverFromRect:CGRectMake(app.detailViewController.view.frame.size.width/2, app.detailViewController.view.frame.size.width/2, 100, 100) inView:app.detailViewController.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+                    
+                }else{
+                    
+                    if (_isTheParentViewACell) {
+                        //Present view from cell from file list
+                        [self.activityPopoverController presentPopoverFromRect:_cellFrame inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
+                        
+                    } else if (_parentButton) {
+                        //Present view from bar button item
+                        [self.activityPopoverController presentPopoverFromBarButtonItem:_parentButton permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+                        
+                    } else {
+                        //Present  view from rect
+                        [self.activityPopoverController presentPopoverFromRect:CGRectMake(100, 100, 200, 400) inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
+                    }
+                }
+            }
             
         }
     }

--- a/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
+++ b/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
@@ -101,18 +101,16 @@
             
             if (_isTheParentViewACell) {
                 
-                [self.documentInteractionController presentOpenInMenuFromRect:self.cellFrame inView:self.parentView animated:YES];
+                [self.documentInteractionController presentOptionsMenuFromRect:self.cellFrame inView:self.parentView animated:YES];
                 
             } else {
                 
                 if (IS_IPHONE) {
-                    [self.documentInteractionController presentOpenInMenuFromRect:CGRectZero inView:presentedView.view animated:YES];
-                    
+                    [self.documentInteractionController presentOptionsMenuFromRect:CGRectZero inView:presentedView.view animated:YES];
+
                 } else {
-                    [self.documentInteractionController presentOpenInMenuFromBarButtonItem:self.parentButton animated:YES];
-                    
+                    [self.documentInteractionController presentOptionsMenuFromBarButtonItem:self.parentButton animated:YES];
                 }
-                
             }
             
         } else {

--- a/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
+++ b/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
@@ -91,100 +91,25 @@
         
         DLog(@"File path is %@", file.localFolder);
         
-        if (k_use_open_with_UIDocumentInteractionController) {
+        //Pass path to url
+        NSURL *url = [NSURL fileURLWithPath:file.localFolder];
+        self.documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:url];
+        [self.documentInteractionController setDelegate:self];
+        
+        if (_isTheParentViewACell) {
             
-            //Pass path to url
-            NSURL *url = [NSURL fileURLWithPath:file.localFolder];
-            self.documentInteractionController = [UIDocumentInteractionController interactionControllerWithURL:url];
-            [self.documentInteractionController setDelegate:self];
-            UIViewController *presentedView = [PresentedViewUtils getPresentedViewControllerInWindow:[[[UIApplication sharedApplication] windows] lastObject]];
-            
-            if (_isTheParentViewACell) {
-                
-                [self.documentInteractionController presentOptionsMenuFromRect:self.cellFrame inView:self.parentView animated:YES];
-                
-            } else {
-                
-                if (IS_IPHONE) {
-                    [self.documentInteractionController presentOptionsMenuFromRect:CGRectZero inView:presentedView.view animated:YES];
-
-                } else {
-                    [self.documentInteractionController presentOptionsMenuFromBarButtonItem:self.parentButton animated:YES];
-                }
-            }
+            [self.documentInteractionController presentOptionsMenuFromRect:self.cellFrame inView:self.parentView animated:YES];
             
         } else {
-                        
-            AppDelegate *app = (AppDelegate *)[[UIApplication sharedApplication]delegate];
-            
-            DLog(@"File path is %@", file.localFolder);
-            
-            //Pass path to url
-            NSURL *url = [NSURL fileURLWithPath:file.localFolder];
-            
-            TTOpenInAppActivity *openInAppActivity;
-            
-            if (_isTheParentViewACell) {
-                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andRect:_cellFrame];
-                
-            }else{
-                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andBarButtonItem:self.parentButton];
-            }
-            
-            
-            if (self.activityView) {
-                [self.activityView dismissViewControllerAnimated:YES completion:nil];
-                self.activityView = nil;
-            }
-            
-            if (self.activityPopoverController) {
-                [self.activityPopoverController dismissPopoverAnimated:YES];
-                self.activityPopoverController = nil;
-            }
-            
-            self.activityView = [[UIActivityViewController alloc] initWithActivityItems:@[url] applicationActivities:@[openInAppActivity]];
             
             if (IS_IPHONE) {
+                [self.documentInteractionController presentOptionsMenuFromRect:CGRectZero inView:self.parentView animated:YES];
                 
-                openInAppActivity.superViewController = self.activityView;
-                
-                [app.ocTabBarController presentViewController:self.activityView animated:YES completion:nil];
             } else {
-                
-                if (self.activityPopoverController) {
-                    [self.activityPopoverController setContentViewController:self.activityView];
-                } else {
-                    self.activityPopoverController = [[UIPopoverController alloc] initWithContentViewController:self.activityView];
-                }
-                
-                openInAppActivity.superViewController = self.activityPopoverController;
-                
-                if (_isTheParentViewACell && IS_PORTRAIT) {
-                    
-                    [self.activityPopoverController presentPopoverFromRect:CGRectMake(app.detailViewController.view.frame.size.width/2, app.detailViewController.view.frame.size.width/2, 100, 100) inView:app.detailViewController.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-                    
-                }else{
-                    
-                    if (_isTheParentViewACell) {
-                        //Present view from cell from file list
-                        [self.activityPopoverController presentPopoverFromRect:_cellFrame inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
-                        
-                    } else if (_parentButton) {
-                        //Present view from bar button item
-                        [self.activityPopoverController presentPopoverFromBarButtonItem:_parentButton permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-                        
-                    } else {
-                        //Present  view from rect
-                        [self.activityPopoverController presentPopoverFromRect:CGRectMake(100, 100, 200, 400) inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
-                    }
-                }
+                [self.documentInteractionController presentOptionsMenuFromBarButtonItem:self.parentButton animated:YES];
             }
-
-            
         }
     }
-    
-    
 }
 
 #pragma mark - UIDocumentInteractionControllerDelegate methods

--- a/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
+++ b/Owncloud iOs Client/Tabs/FileTab/OpenWith/OpenWith.m
@@ -25,7 +25,6 @@
 #import "Customization.h"
 
 
-
 @implementation OpenWith
 
 
@@ -111,6 +110,7 @@
             }
         }else {
             
+            
             AppDelegate *app = (AppDelegate *)[[UIApplication sharedApplication]delegate];
             
             DLog(@"File path is %@", file.localFolder);
@@ -118,63 +118,93 @@
             //Pass path to url
             NSURL *url = [NSURL fileURLWithPath:file.localFolder];
             
-            TTOpenInAppActivity *openInAppActivity;
             
-            if (_isTheParentViewACell) {
-                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andRect:_cellFrame];
-                
-            }else{
-                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andBarButtonItem:self.parentButton];
-            }
+            UIActivityItemProvider *activityProvider = [[UIActivityItemProvider alloc] initWithPlaceholderItem:url];
+            NSArray *items = @[activityProvider,url];
+            
+            NSMutableArray *activities = [NSMutableArray new];
             
             
-            if (self.activityView) {
-                [self.activityView dismissViewControllerAnimated:YES completion:nil];
-                self.activityView = nil;
-            }
+            self.activityView = [[UIActivityViewController alloc]
+                                                      initWithActivityItems:items
+                                                      applicationActivities:activities];
             
-            if (self.activityPopoverController) {
-                [self.activityPopoverController dismissPopoverAnimated:YES];
-                self.activityPopoverController = nil;
-            }
-            
-            self.activityView = [[UIActivityViewController alloc] initWithActivityItems:@[url] applicationActivities:@[openInAppActivity]];
+                [self.activityView setExcludedActivityTypes:
+                 @[UIActivityTypeAssignToContact,
+                   UIActivityTypeCopyToPasteboard,
+                   UIActivityTypePrint,
+                   UIActivityTypeSaveToCameraRoll,
+                   UIActivityTypePostToWeibo]];
             
             if (IS_IPHONE) {
-                
-                openInAppActivity.superViewController = self.activityView;
-                
+
                 [app.ocTabBarController presentViewController:self.activityView animated:YES completion:nil];
-            } else {
-                
-                if (self.activityPopoverController) {
-                    [self.activityPopoverController setContentViewController:self.activityView];
-                } else {
-                    self.activityPopoverController = [[UIPopoverController alloc] initWithContentViewController:self.activityView];
-                }
-                
-                openInAppActivity.superViewController = self.activityPopoverController;
-                
-                if (_isTheParentViewACell && IS_PORTRAIT) {
-                    
-                    [self.activityPopoverController presentPopoverFromRect:CGRectMake(app.detailViewController.view.frame.size.width/2, app.detailViewController.view.frame.size.width/2, 100, 100) inView:app.detailViewController.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-                    
-                }else{
-                    
-                    if (_isTheParentViewACell) {
-                        //Present view from cell from file list
-                        [self.activityPopoverController presentPopoverFromRect:_cellFrame inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
-                        
-                    } else if (_parentButton) {
-                        //Present view from bar button item
-                        [self.activityPopoverController presentPopoverFromBarButtonItem:_parentButton permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
-                        
-                    } else {
-                        //Present  view from rect
-                        [self.activityPopoverController presentPopoverFromRect:CGRectMake(100, 100, 200, 400) inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
-                    }
-                }
             }
+            
+//            else {
+//
+//                self.activityPopoverController = [[UIPopoverController alloc] initWithContentViewController:self.activityView];
+//
+//                [self.activityPopoverController presentPopoverFromRect:CGRectMake(100, 100, 200, 400) inView:sender permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+//            }
+            
+//            TTOpenInAppActivity *openInAppActivity;
+//
+//            if (_isTheParentViewACell) {
+//                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andRect:_cellFrame];
+//
+//            }else{
+//                openInAppActivity = [[TTOpenInAppActivity alloc] initWithView:self.parentView andBarButtonItem:self.parentButton];
+//            }
+//
+//
+//            if (self.activityView) {
+//                [self.activityView dismissViewControllerAnimated:YES completion:nil];
+//                self.activityView = nil;
+//            }
+//
+//            if (self.activityPopoverController) {
+//                [self.activityPopoverController dismissPopoverAnimated:YES];
+//                self.activityPopoverController = nil;
+//            }
+//
+//            self.activityView = [[UIActivityViewController alloc] initWithActivityItems:@[url] applicationActivities:@[openInAppActivity]];
+//
+//            if (IS_IPHONE) {
+//
+//                openInAppActivity.superViewController = self.activityView;
+//
+//                [app.ocTabBarController presentViewController:self.activityView animated:YES completion:nil];
+//            } else {
+//
+//                if (self.activityPopoverController) {
+//                    [self.activityPopoverController setContentViewController:self.activityView];
+//                } else {
+//                    self.activityPopoverController = [[UIPopoverController alloc] initWithContentViewController:self.activityView];
+//                }
+//
+//                openInAppActivity.superViewController = self.activityPopoverController;
+//
+//                if (_isTheParentViewACell && IS_PORTRAIT) {
+//
+//                    [self.activityPopoverController presentPopoverFromRect:CGRectMake(app.detailViewController.view.frame.size.width/2, app.detailViewController.view.frame.size.width/2, 100, 100) inView:app.detailViewController.view permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+//
+//                }else{
+//
+//                    if (_isTheParentViewACell) {
+//                        //Present view from cell from file list
+//                        [self.activityPopoverController presentPopoverFromRect:_cellFrame inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
+//
+//                    } else if (_parentButton) {
+//                        //Present view from bar button item
+//                        [self.activityPopoverController presentPopoverFromBarButtonItem:_parentButton permittedArrowDirections:UIPopoverArrowDirectionAny animated:YES];
+//
+//                    } else {
+//                        //Present  view from rect
+//                        [self.activityPopoverController presentPopoverFromRect:CGRectMake(100, 100, 200, 400) inView:_parentView permittedArrowDirections:UIPopoverArrowDirectionLeft animated:YES];
+//                    }
+//                }
+//            }
             
         }
     }

--- a/Owncloud iOs Client/Utils/SystemConstants.h
+++ b/Owncloud iOs Client/Utils/SystemConstants.h
@@ -23,7 +23,3 @@
 #define IS_PORTRAIT (([[UIApplication sharedApplication] statusBarOrientation] == UIInterfaceOrientationPortrait) || [[UIApplication sharedApplication] statusBarOrientation] == UIInterfaceOrientationPortraitUpsideDown)
 #define APP_DELEGATE ((AppDelegate *)[[UIApplication sharedApplication] delegate])
 #define IS_IPHONE_PLUS (IS_IPHONE && SCREEN_MAX_LENGTH == 736.0)
-
-//openWith mode
-//only use open with UIDocumentInteraciton with iOS<11 until fix the issue with UIDocumentInteractionController in iOS11
-#define k_use_open_with_UIDocumentInteractionController YES

--- a/Owncloud iOs Client/Utils/SystemConstants.h
+++ b/Owncloud iOs Client/Utils/SystemConstants.h
@@ -26,4 +26,4 @@
 
 //openWith mode
 //only use open with UIDocumentInteraciton with iOS<11 until fix the issue with UIDocumentInteractionController in iOS11
-#define k_use_open_with_UIDocumentInteractionController !IS_IOS11
+#define k_use_open_with_UIDocumentInteractionController YES

--- a/Owncloud iOs ClientTests/Owncloud iOs ClientTests-Info.plist
+++ b/Owncloud iOs ClientTests/Owncloud iOs ClientTests-Info.plist
@@ -13,11 +13,11 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.2</string>
+	<string>3.7.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.1</string>
+	<string>1.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/ownCloudExtApp/Info.plist
+++ b/ownCloudExtApp/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.2</string>
+	<string>3.7.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.1</string>
+	<string>1.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>

--- a/ownCloudExtAppFileProvider/Info.plist
+++ b/ownCloudExtAppFileProvider/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.7.2</string>
+	<string>3.7.3</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.1</string>
+	<string>1.0</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSAppTransportSecurity</key>


### PR DESCRIPTION
- [x] Fix crash saving photo into camera roll due new usage description message required on iOS11. 
(Still pending to add translation file into transifex in future US)
- [x] Added also usage description message for faceId

STEPS TO REPRODUCE:
1. Preview photo inside OC iOS app
2. Tap to share with openWith
3. Select the activity "save image"

CURRENT BEHAVIOR
App crash

EXPECTED BEHAVIOR
Photo is saved in the camera roll.

Device: iPhone iOS11