### PR TITLE
Fix migrate accounts to new URL

### DIFF
--- a/Owncloud iOs Client/AppDelegate.m
+++ b/Owncloud iOs Client/AppDelegate.m
@@ -713,23 +713,6 @@ float shortDelay = 0.3;
     
 }
 
-#pragma mark - UpdateDisplayNameOfUser
-
-/*
- * This method is for launch the process update the displayName of user in background
- */
-- (void) launchProcessToUpdateDisplayNameOfUser {
-    
-    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-        
-        if (self.activeUser.username == nil) {
-            self.activeUser = [ManageUsersDB getActiveUser];
-        }
-        ManageAccounts *manageAccounts = [ManageAccounts new];
-        [manageAccounts updateDisplayNameOfUserWithUser:self.activeUser];
-    });
-}
-
 #pragma mark - DetailViewController Methods for iPad
 
 - (void)cancelDonwloadInDetailView{

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -936,17 +936,14 @@ public enum TextfieldType: String {
 
                         if self.loginMode != .create {
                             self.userNewCredentials.userId = String(self.user!.userId)
-                            
-                            if self.loginMode == .migrate {
-                                self.user!.predefinedUrl = k_default_url_server
-                            }
                         }
                         self.user!.url = self.validatedServerURL
                         self.user!.username = self.userNewCredentials.userName
                         self.user!.ssl = self.validatedServerURL.hasPrefix("https")
                         self.user!.urlRedirected = app.urlServerRedirected
                     }
-
+                    
+                    self.user!.predefinedUrl = k_default_url_server
                     self.userNewCredentials.baseURL = UtilsUrls.getFullRemoteServerPath(self.user)
                     
                     if self.forceAccountMigration {

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -931,15 +931,15 @@ public enum TextfieldType: String {
                     self.showCredentialsError(NSLocalizedString("credentials_different_user", comment: "") )
                     
                 } else {
-
+                    
                     switch self.loginMode! {
                         case .create:
                             self.user = UserDto()
-                            self.setCurrentUrlUsernameSSLAndUrlRedirectedUserProperties()
+                            self.user = self.setPropertiesOfUser(user: self.user!, url: self.validatedServerURL, username: self.userNewCredentials.userName, urlServerRedirected: app.urlServerRedirected)
                             break
                         case .migrate:
                             self.userNewCredentials.userId = String(self.user!.userId)
-                            self.setCurrentUrlUsernameSSLAndUrlRedirectedUserProperties()
+                            self.user = self.setPropertiesOfUser(user: self.user!, url: self.validatedServerURL, username: self.userNewCredentials.userName, urlServerRedirected: app.urlServerRedirected)
                             break
                         default:
                             break
@@ -1035,13 +1035,15 @@ public enum TextfieldType: String {
         self.user = user
     }
     
-    func setCurrentUrlUsernameSSLAndUrlRedirectedUserProperties() {
-        let app: AppDelegate = (UIApplication.shared.delegate as! AppDelegate)
-
-        self.user!.url = self.validatedServerURL
-        self.user!.username = self.userNewCredentials.userName
-        self.user!.ssl = self.validatedServerURL.hasPrefix(K.constant.httpsPrefix)
-        self.user!.urlRedirected = app.urlServerRedirected
+    
+    func setPropertiesOfUser(user: UserDto, url: String, username: String, urlServerRedirected: String) -> UserDto {
+       
+        user.url = url
+        user.username = username
+        user.ssl = url.hasPrefix(K.constant.httpsPrefix)
+        user.urlRedirected = urlServerRedirected
+        
+        return user
     }
     
 }

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -538,53 +538,54 @@ public enum TextfieldType: String {
             self.setNetworkActivityIndicator(status: true)
             // get public infor from server
             getPublicInfoFromServerJob.start(serverURL: self.serverURLNormalizer.normalizedURL, withCompletion: { (validatedURL: String?, _ serverAuthenticationMethods: Array<Any>?, _ error: Error?, _ httpStatusCode: NSInteger) in
-            
-                self.setNetworkActivityIndicator(status: false)
-                if (error != nil || validatedURL == nil) {
-                    
-                    self.setConnectButton(status: false)
-                    self.showURLError(
-                        self.manageNetworkErrors.returnErrorMessage(
-                            withHttpStatusCode: httpStatusCode, andError: error
+                
+                DispatchQueue.main.async {
+                    self.setNetworkActivityIndicator(status: false)
+                    if (error != nil || validatedURL == nil) {
+                        
+                        self.setConnectButton(status: false)
+                        self.showURLError(
+                            self.manageNetworkErrors.returnErrorMessage(
+                                withHttpStatusCode: httpStatusCode, andError: error
+                            )
                         )
-                    )
-                    print ("error getting information from URL")
-                    
-                } else if validatedURL != nil {
-                    
-                    self.setURLFooter(isType: .None)
-                    
-                    self.validatedServerURL = validatedURL;
-                    self.allAvailableAuthMethods = serverAuthenticationMethods as! [AuthenticationMethod]
-                    
-                    self.authMethodToLogin = DetectAuthenticationMethod.getAuthMethodToLoginFrom(availableAuthMethods: self.allAvailableAuthMethods)
-                    
-                    if (self.authMethodToLogin != .NONE) {
-                        self.setReconnectionButtons(hiddenStatus: true)
-
-                        if (self.authMethodToLogin == .BASIC_HTTP_AUTH) {
-                            self.textFieldURL.resignFirstResponder()
-                            self.textFieldUsername.becomeFirstResponder()
+                        print ("error getting information from URL")
+                        
+                    } else if validatedURL != nil {
+                        
+                        self.setURLFooter(isType: .None)
+                        
+                        self.validatedServerURL = validatedURL;
+                        self.allAvailableAuthMethods = serverAuthenticationMethods as! [AuthenticationMethod]
+                        
+                        self.authMethodToLogin = DetectAuthenticationMethod.getAuthMethodToLoginFrom(availableAuthMethods: self.allAvailableAuthMethods)
+                        
+                        if (self.authMethodToLogin != .NONE) {
+                            self.setReconnectionButtons(hiddenStatus: true)
                             
-                            if self.loginMode == .update {
-                                self.textFieldUsername.text = self.user?.username
-                                self.textFieldPassword.text = ""
+                            if (self.authMethodToLogin == .BASIC_HTTP_AUTH) {
+                                self.textFieldURL.resignFirstResponder()
+                                self.textFieldUsername.becomeFirstResponder()
+                                
+                                if self.loginMode == .update {
+                                    self.textFieldUsername.text = self.user?.username
+                                    self.textFieldPassword.text = ""
+                                }
+                            } else {
+                                self.setConnectButton(status: false)
+                                self.startAuthenticationWith(authMethod: self.authMethodToLogin)
                             }
+                            
+                            self.showURLSuccess(self.validatedServerURL.hasPrefix("https://"))
+                            
                         } else {
                             self.setConnectButton(status: false)
-                            self.startAuthenticationWith(authMethod: self.authMethodToLogin)
+                            self.showURLError(NSLocalizedString("authentification_not_valid", comment: ""))
                         }
-                        
-                        self.showURLSuccess(self.validatedServerURL.hasPrefix("https://"))
-                        
-                    } else {
-                        self.setConnectButton(status: false)
-                        self.showURLError(NSLocalizedString("authentification_not_valid", comment: ""))
+                        self.updateUIWithNormalizedData(self.serverURLNormalizer)
                     }
-                    self.updateUIWithNormalizedData(self.serverURLNormalizer)
+                    self.updateInputFieldsFromCurrentAuthMethodToLogin()
                 }
-                
-                self.updateInputFieldsFromCurrentAuthMethodToLogin()
             })
         }
     }

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -551,11 +551,12 @@ public enum TextfieldType: String {
                         )
                         print ("error getting information from URL")
                         
-                    } else if validatedURL != nil {
+                    } else if (validatedURL != nil && (serverAuthenticationMethods != nil && serverAuthenticationMethods!.count > 0) ) {
                         
                         self.setURLFooter(isType: .None)
                         
                         self.validatedServerURL = validatedURL;
+                        
                         self.allAvailableAuthMethods = serverAuthenticationMethods as! [AuthenticationMethod]
                         
                         self.authMethodToLogin = DetectAuthenticationMethod.getAuthMethodToLoginFrom(availableAuthMethods: self.allAvailableAuthMethods)
@@ -908,7 +909,7 @@ public enum TextfieldType: String {
             let app: AppDelegate = (UIApplication.shared.delegate as! AppDelegate)
             
             if (listOfFileDtos != nil && !((listOfFileDtos?.isEmpty)!)) {
-                /// credentials allowed access to root folder: well done
+                print("credentials allowed access to root folder: well done!")
                 
                 let tryingToUpdateDifferentUser = (self.user != nil &&
                     (self.loginMode == .update || self.loginMode == .expire)

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -661,12 +661,6 @@ public enum TextfieldType: String {
         self.userNewCredentials.accessToken = cookieString;
         self.userNewCredentials.authenticationMethod = .SAML_WEB_SSO;
         
-        if self.loginMode == .expire {
-            let app: AppDelegate = (UIApplication.shared.delegate as! AppDelegate)
-            self.userNewCredentials.userName = app.activeUser.username
-        }
-        
-        
         if cookieString == nil || cookieString == "" {
             self.showCredentialsError(NSLocalizedString("authentification_not_valid", comment: "") )
             
@@ -874,9 +868,10 @@ public enum TextfieldType: String {
 // MARK: 'private' methods
     
     func detectUserDataAndValidate(serverPath: String) {
-        if loginMode == .migrate || self.forceAccountMigration{
-            //credentials may have changed, remove cookies
-            UtilsCookies.deleteAllCookiesOfActiveUser()
+        
+        if loginMode != .create {
+            //credentials may have changed, remove and update cookies
+            UtilsCookies.updateOfActiveUserInDB()
         }
         
         DetectUserData .getUserDisplayName(ofServer: serverPath, credentials: self.userNewCredentials) { (serverUserID, displayName, error) in

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -932,31 +932,27 @@ public enum TextfieldType: String {
                     
                 } else {
 
-                    //1.Generate correct user
-                    if self.loginMode == .create {
-                        self.user = UserDto()
-                    }
-                    
-                    if self.loginMode == .create || self.loginMode == .migrate || self.forceAccountMigration {
-
-                        if self.loginMode != .create {
+                    switch self.loginMode! {
+                        case .create:
+                            self.user = UserDto()
+                            self.setCurrentUrlUsernameSSLAndUrlRedirectedUserProperties()
+                            break
+                        case .migrate:
                             self.userNewCredentials.userId = String(self.user!.userId)
-                        }
-                        self.user!.url = self.validatedServerURL
-                        self.user!.username = self.userNewCredentials.userName
-                        self.user!.ssl = self.validatedServerURL.hasPrefix(K.constant.httpsPrefix)
-                        self.user!.urlRedirected = app.urlServerRedirected
+                            self.setCurrentUrlUsernameSSLAndUrlRedirectedUserProperties()
+                            break
+                        default:
+                            break
                     }
                     
                     self.user!.predefinedUrl = k_default_url_server
                     self.userNewCredentials.baseURL = UtilsUrls.getFullRemoteServerPath(self.user)
                     
                     if self.forceAccountMigration {
+                        self.userNewCredentials.userId = String(self.user!.userId)
                         OCKeychain.storeCredentials(self.userNewCredentials)
                     }
-                    
 
-                    //2.Store account
                     if self.loginMode == .create {
                         
                         if (ManageUsersDB.isExistUser(self.user)) {
@@ -1037,6 +1033,15 @@ public enum TextfieldType: String {
     @objc func setLoginMode(loginMode: LoginMode, user: UserDto) {
         self.loginMode = loginMode
         self.user = user
+    }
+    
+    func setCurrentUrlUsernameSSLAndUrlRedirectedUserProperties() {
+        let app: AppDelegate = (UIApplication.shared.delegate as! AppDelegate)
+
+        self.user!.url = self.validatedServerURL
+        self.user!.username = self.userNewCredentials.userName
+        self.user!.ssl = self.validatedServerURL.hasPrefix("https")
+        self.user!.urlRedirected = app.urlServerRedirected
     }
     
 }

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -935,11 +935,11 @@ public enum TextfieldType: String {
                     switch self.loginMode! {
                         case .create:
                             self.user = UserDto()
-                            self.user = self.setPropertiesOfUser(user: self.user!, url: self.validatedServerURL, username: self.userNewCredentials.userName, urlServerRedirected: app.urlServerRedirected)
+                            self.setPropertiesOfGlobalUser(url: self.validatedServerURL, username: self.userNewCredentials.userName, urlServerRedirected: app.urlServerRedirected)
                             break
                         case .migrate:
                             self.userNewCredentials.userId = String(self.user!.userId)
-                            self.user = self.setPropertiesOfUser(user: self.user!, url: self.validatedServerURL, username: self.userNewCredentials.userName, urlServerRedirected: app.urlServerRedirected)
+                            self.setPropertiesOfGlobalUser(url: self.validatedServerURL, username: self.userNewCredentials.userName, urlServerRedirected: app.urlServerRedirected)
                             break
                         default:
                             break
@@ -1036,14 +1036,12 @@ public enum TextfieldType: String {
     }
     
     
-    func setPropertiesOfUser(user: UserDto, url: String, username: String, urlServerRedirected: String) -> UserDto {
+    func setPropertiesOfGlobalUser(url: String, username: String, urlServerRedirected: String) {
        
-        user.url = url
-        user.username = username
-        user.ssl = url.hasPrefix(K.constant.httpsPrefix)
-        user.urlRedirected = urlServerRedirected
-        
-        return user
+        self.user!.url = url
+        self.user!.username = username
+        self.user!.ssl = url.hasPrefix(K.constant.httpsPrefix)
+        self.user!.urlRedirected = urlServerRedirected
     }
     
 }

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -1040,7 +1040,7 @@ public enum TextfieldType: String {
 
         self.user!.url = self.validatedServerURL
         self.user!.username = self.userNewCredentials.userName
-        self.user!.ssl = self.validatedServerURL.hasPrefix("https")
+        self.user!.ssl = self.validatedServerURL.hasPrefix(K.constant.httpsPrefix)
         self.user!.urlRedirected = app.urlServerRedirected
     }
     

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -28,6 +28,14 @@ struct K {
     struct vcId {
         static let vcIdWebViewLogin = "WebViewLoginViewController"
     }
+    
+    struct constant {
+        static let httpsProtocol = "https://"
+        static let httpProtocol = "http://"
+        static let httpsPrefix = "https"
+        static let httpPrefix = "http"
+
+    }
 }
 
 public enum TextfieldType: String {
@@ -577,7 +585,7 @@ public enum TextfieldType: String {
                                 self.startAuthenticationWith(authMethod: self.authMethodToLogin)
                             }
                             
-                            self.showURLSuccess(self.validatedServerURL.hasPrefix("https://"))
+                            self.showURLSuccess(self.validatedServerURL.hasPrefix(K.constant.httpsProtocol))
                             
                         } else {
                             self.setConnectButton(status: false)
@@ -936,7 +944,7 @@ public enum TextfieldType: String {
                         }
                         self.user!.url = self.validatedServerURL
                         self.user!.username = self.userNewCredentials.userName
-                        self.user!.ssl = self.validatedServerURL.hasPrefix("https")
+                        self.user!.ssl = self.validatedServerURL.hasPrefix(K.constant.httpsPrefix)
                         self.user!.urlRedirected = app.urlServerRedirected
                     }
                     

--- a/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
+++ b/Owncloud iOs Client/Login/Login/UniversalLoginViewController.swift
@@ -1036,7 +1036,7 @@ public enum TextfieldType: String {
     }
     
     
-    func setPropertiesOfGlobalUser(url: String, username: String, urlServerRedirected: String) {
+    func setPropertiesOfGlobalUser(url: String, username: String, urlServerRedirected: String?) {
        
         self.user!.url = url
         self.user!.username = username

--- a/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
+++ b/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
@@ -1324,7 +1324,7 @@
         if (fileCell == nil) {
             NSArray *topLevelObjects = [[NSBundle mainBundle] loadNibNamed:@"CustomCellFileAndDirectory" owner:self options:nil];
             fileCell = (CustomCellFileAndDirectory *)[topLevelObjects objectAtIndex:0];
-        }
+        } 
         
         if (!IS_IPHONE) {
             fileCell.labelTitle.adjustsFontSizeToFitWidth=YES;
@@ -1339,6 +1339,9 @@
             [fileCell.labelInfoFile setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
         }
         
+        if (indexPath.section && indexPath.row) {
+            
+        }
         FileDto *file = (FileDto *)[[_sortedArray objectAtIndex:indexPath.section]objectAtIndex:indexPath.row];
         
         NSDate* date = [NSDate dateWithTimeIntervalSince1970:file.date];

--- a/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
+++ b/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
@@ -1339,9 +1339,6 @@
             [fileCell.labelInfoFile setAutoresizingMask:UIViewAutoresizingFlexibleWidth];
         }
         
-        if (indexPath.section && indexPath.row) {
-            
-        }
         FileDto *file = (FileDto *)[[_sortedArray objectAtIndex:indexPath.section]objectAtIndex:indexPath.row];
         
         NSDate* date = [NSDate dateWithTimeIntervalSince1970:file.date];

--- a/Owncloud iOs Client/Tabs/SettingTab/Account/ManageAccounts.swift
+++ b/Owncloud iOs Client/Tabs/SettingTab/Account/ManageAccounts.swift
@@ -74,24 +74,19 @@ import Foundation
 @objc func migrateAccountOfUser(_ user: UserDto, withCredentials credDto: OCCredentialsDto) {
         
         //Update parameters after a force url and credentials have not been renewed
+    
         let app: AppDelegate = (UIApplication.shared.delegate as! AppDelegate)
-
-        if Customization.kIsSsoActive() {
-          //  user.username =
-        }
-        
-        user.urlRedirected = app.urlServerRedirected
+    
         user.predefinedUrl = k_default_url_server
-        
+    
         ManageUploadsDB.overrideAllUploads(withNewURL: UtilsUrls.getFullRemoteServerPath(user))
         
-        ManageUsersDB.updateUser(by: user)
-        
-        
         self.updateAccountOfUser(user, withCredentials: credDto)
+    
+        self.updateDisplayNameOfUser(user: user)
         
         app.updateStateAndRestoreUploadsAndDownloads()
-         //[[APP_DELEGATE presentFilesViewController] initFilesView];
+
         let instantUploadManager: InstantUpload = InstantUpload.instantUploadManager()
         instantUploadManager.activate()
     }
@@ -128,7 +123,6 @@ import Foundation
                             user.credDto.userDisplayName = displayName
                             
                             OCKeychain.updateCredentials(user.credDto)
-                            
                             
                             if (user.activeaccount) {
                                 let app: AppDelegate = (UIApplication.shared.delegate as! AppDelegate)


### PR DESCRIPTION
- [x] In migration mode all account will be updated to the new url
- [x] In expiration mode and force migrate due empty username the active user will be updated
- [X] All app settings should remain

Note: test all different login view modes in all authentication modes

____ 

BUGS & IMPROVEMENTS

- [X] (1) New account after migration https://github.com/owncloud/ios/pull/1020#issuecomment-363039462 [FIXED]
- [X] (2) Migration basic -> saml with error https://github.com/owncloud/ios/pull/1020#issuecomment-363058441  [FIXED]
- [X] (3) Migration from redirected server points to expiration login view https://github.com/owncloud/ios/pull/1020#issuecomment-363069140   [FIXED]
- [X] (4) App crashes after login https://github.com/owncloud/ios/pull/1020#issuecomment-366167302 [FIXED]