### PR TITLE
Fix tint of logo image item in navigation bar. && artWork image

### DIFF
--- a/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
+++ b/Owncloud iOs Client/Tabs/FileTab/FilesViewController.m
@@ -63,6 +63,7 @@
 #import "SortManager.h"
 #import "EditFileViewController.h"
 #import "CheckFeaturesSupported.h"
+#import "ImageUtils.h"
 
 //Constant for iOS7
 #define k_status_bar_height 20
@@ -228,8 +229,9 @@
     if(self.fileIdToShowFiles.isRootFolder) {
         
         if(k_show_logo_on_title_file_list) {
-            UIImageView *imageView = [[UIImageView alloc]initWithImage:[UIImage imageNamed:[FileNameUtils getTheNameOfTheBrandImage]]];
-            self.navigationItem.titleView=imageView;
+
+            UIImageView *imageView = [[UIImageView alloc]initWithImage:[ImageUtils getNavigationLogoImage]];
+            self.navigationItem.titleView = imageView;
         }
     }
 }
@@ -469,8 +471,9 @@
     
     if(self.navigationItem.title == nil) {
         // in MyTableViewController's tableView:didSelectRowAtIndexPath method...
+
         UIBarButtonItem *backButton = [[UIBarButtonItem alloc]
-                                       initWithImage:[UIImage imageNamed:[FileNameUtils getTheNameOfTheBrandImage]]
+                                       initWithImage:[ImageUtils getNavigationLogoImage]
                                        style:UIBarButtonItemStylePlain
                                        target:nil
                                        action:nil];
@@ -1632,8 +1635,9 @@
 
         // If the file is in root folder, show icon instead of folder name.
         if(self.fileIdToShowFiles.isRootFolder){
+
             UIBarButtonItem *backButton = [[UIBarButtonItem alloc]
-                                           initWithImage:[UIImage imageNamed:[FileNameUtils getTheNameOfTheBrandImage]]
+                                           initWithImage:[ImageUtils getNavigationLogoImage]
                                            style:UIBarButtonItemStylePlain
                                            target:nil
                                            action:nil];

--- a/Owncloud iOs Client/Tabs/FileTab/SimpleFileList/SimpleFileListTableViewController.m
+++ b/Owncloud iOs Client/Tabs/FileTab/SimpleFileList/SimpleFileListTableViewController.m
@@ -35,6 +35,7 @@
 #import "FileListDBOperations.h"
 #import "UIColor+Constants.h"
 #import "SortManager.h"
+#import "ImageUtils.h"
 
 #ifdef CONTAINER_APP
 #import "AppDelegate.h"
@@ -88,7 +89,8 @@
     if(self.currentFolder.isRootFolder) {
         
         if(k_show_logo_on_title_file_list) {
-            UIImageView *imageView = [[UIImageView alloc]initWithImage:[UIImage imageNamed:[FileNameUtils getTheNameOfTheBrandImage]]];
+
+            UIImageView *imageView = [[UIImageView alloc]initWithImage:[ImageUtils getNavigationLogoImage]];
             self.navigationItem.titleView = imageView;
         }
     } else {

--- a/Owncloud iOs Client/Utils/FileNameUtils.h
+++ b/Owncloud iOs Client/Utils/FileNameUtils.h
@@ -113,20 +113,6 @@ typedef NS_ENUM (NSInteger, kindOfFileEnum){
 + (BOOL) isURLWithSamlFragment:(NSHTTPURLResponse *)response;
 
 
-///-----------------------------------
-/// @name Get the Name of the Brand Image
-///-----------------------------------
-/**
- * This method return a string with the name of the brand image
- * Used by ownCloud and other brands
- *
- * If the day of the year is 354 or more the string return is an
- * especial image for Christmas day.
- *
- * @return image name -> NSString
- */
-+ (NSString *)getTheNameOfTheBrandImage;
-
 
 ///-----------------------------------
 /// @name Get the Name of shared path

--- a/Owncloud iOs Client/Utils/FileNameUtils.m
+++ b/Owncloud iOs Client/Utils/FileNameUtils.m
@@ -292,28 +292,6 @@
 }
 
 
-+ (NSString *)getTheNameOfTheBrandImage{
-    
-    NSString *imageName;
-    
-    //Default name
-    imageName = @"BackRootFolderIcon";
-    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
-    //The special icon for chritmats only for ownCloud app
-    if ([appName isEqualToString:@"ownCloud"]) {
-        // After day 354 of the year, the usual ownCloud icon is replaced by another icon
-        NSCalendar *gregorian =
-        [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-        NSUInteger dayOfYear = [gregorian ordinalityOfUnit:NSCalendarUnitDay inUnit:NSCalendarUnitYear forDate:[NSDate date]];
-        if (dayOfYear >= 354)
-            imageName = @"ownCloud-xmas";
-        
-    }
-    
-    return imageName;
-}
-
-
 + (NSString*)getTheNameOfSharedPath:(NSString*)sharedPath isDirectory:(BOOL)isDirectory{
     
     NSString *output;

--- a/Owncloud iOs Client/Utils/ImageUtils.h
+++ b/Owncloud iOs Client/Utils/ImageUtils.h
@@ -27,4 +27,29 @@
  */
 + (UIImage *)imageWithColor:(UIColor *)color;
 
+
+///-----------------------------------
+/// @name Get the Name of the Brand Image
+///-----------------------------------
+/**
+ * This method return a string with the name of the brand image
+ * Used by ownCloud and other brands
+ *
+ * If the day of the year is 354 or more the string return is an
+ * especial image for Christmas day.
+ *
+ * @return image name -> NSString
+ */
++ (NSString *)getTheNameOfTheBrandImage;
+
+///-----------------------------------
+/// @name Get Logo Image to use in the navigation bar
+///-----------------------------------
+/**
+ * This method return an image with the rendering mode AlwaysOriginal
+ *
+ * @return image -> UIIMAGE
+ */
++ (UIImage *)getNavigationLogoImage;
+
 @end

--- a/Owncloud iOs Client/Utils/ImageUtils.m
+++ b/Owncloud iOs Client/Utils/ImageUtils.m
@@ -43,4 +43,33 @@
     return image;
 }
 
++ (NSString *)getTheNameOfTheBrandImage {
+
+    NSString *imageName;
+
+    //Default name
+    imageName = @"BackRootFolderIcon";
+    NSString *appName = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleDisplayName"];
+    //The special icon for chritmats only for ownCloud app
+    if ([appName isEqualToString:@"ownCloud"]) {
+        // After day 354 of the year, the usual ownCloud icon is replaced by another icon
+        NSCalendar *gregorian =
+        [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
+        NSUInteger dayOfYear = [gregorian ordinalityOfUnit:NSCalendarUnitDay inUnit:NSCalendarUnitYear forDate:[NSDate date]];
+        if (dayOfYear >= 354)
+            imageName = @"ownCloud-xmas";
+
+    }
+
+    return imageName;
+}
+
++ (UIImage *)getNavigationLogoImage {
+
+    UIImage *logoImage = [UIImage imageNamed:[self getTheNameOfTheBrandImage]];
+    logoImage = [logoImage imageWithRenderingMode:UIImageRenderingModeAlwaysOriginal];
+
+    return logoImage;
+}
+
 @end


### PR DESCRIPTION
- [X] This fix an issue with the tint color and set the navigation logo item to keep original aspect and not use it as a template.

Before:
<img width="261" alt="screen shot 2018-03-22 at 15 27 08" src="https://user-images.githubusercontent.com/6570505/37776412-82b2cca6-2de5-11e8-83d0-64c8da7a7a7c.png">




After:
<img width="257" alt="screen shot 2018-03-22 at 15 25 30" src="https://user-images.githubusercontent.com/6570505/37776324-4dcc08f4-2de5-11e8-8d25-b11187ad1a8e.png">


- [X] Remove iTunes artWork images, now are going to be handle with the asset