### PR TITLE
Removed the body of the propfind request to get the authentication method of the server

### DIFF
--- a/Owncloud iOs Client/Network/Authentication/DetectAuthenticationMethod.swift
+++ b/Owncloud iOs Client/Network/Authentication/DetectAuthenticationMethod.swift
@@ -36,9 +36,7 @@ import Foundation
         request.setValue("0", forHTTPHeaderField: "Depth")
         request.setValue(UtilsUrls.getUserAgent(), forHTTPHeaderField: "User-Agent")
         request.setValue("application/xml", forHTTPHeaderField: "Content-Type")
-        let body =  "<?xml version=\"1.0\" encoding=\"UTF-8\"?><D:propfind xmlns:D=\"DAV:\"><D:prop><D:resourcetype/><D:getlastmodified/><size xmlns=\"http://owncloud.org/ns\"/><D:creationdate/><id xmlns=\"http://owncloud.org/ns\"/><D:getcontentlength/><D:displayname/><D:quota-available-bytes/><D:getetag/><permissions xmlns=\"http://owncloud.org/ns\"/><D:quota-used-bytes/><D:getcontenttype/></D:prop></D:propfind>"
-        request.httpBody = body.data(using: String.Encoding.utf8)
-        
+
         let configuration = URLSessionConfiguration.ephemeral
         configuration.urlCredentialStorage = nil;   // enforce that no credential is proposed for the auhtentication challenge
         let session = URLSession(configuration: configuration, delegate: self, delegateQueue: OperationQueue.main)


### PR DESCRIPTION
## Description
We are receiving a timeout on the Login view when the user try to connect with an app wrapped with Mobile Iron through a tunnel.

`The Device` send a `PROPFIND` without credentials -> `The Tunnel` receive the request and send it to the `ownCloud server` -> The `ownCloud server` receive the request and return a 401 to the Tunnel -> The tunnel return a timeout to The Device

The problem it is on `The Tunnel`:
Could be on the return of the 401 error from the `ownCloud server` to `The Tunnel` or from the tunnel to `The device`.

As work around if we do not send the body on the `PROPFIND` request `The Tunnel` do everything as we expected