### PR TITLE
Link the FAQ into the manual's table of contents

### DIFF
--- a/user_manual/index.rst
+++ b/user_manual/index.rst
@@ -6,3 +6,4 @@ ownCloud iOS App Manual
    :maxdepth: 2
  
    ios_app
+   ios_faq


### PR DESCRIPTION
Thanks to @michaelstingl for pointing out this omission. This relates to #839.