### PR TITLE
Update Docs As Legacy

### DIFF
--- a/docs/antora.yml
+++ b/docs/antora.yml
@@ -1,5 +1,5 @@
 name: ios
-title: Mobile app for iOS
+title: Mobile App for iOS (Legacy)
 version: master
 start_page: ROOT:index.adoc
 nav:


### PR DESCRIPTION
As this version of the app is now the legacy version, then it makes sense to label it as such (so that it's clear in the live docs, which version is the old and which is the new). This relates to https://github.com/owncloud/docs/issues/1356.